### PR TITLE
WIP: fix mismatch between interface and call site

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,10 @@ Unreleased
 
 *
 
+[0.1.4] - 2019-07-02
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Added an endpoint for this history of bulk management operations on grade overrides. 
+
 [0.1.0] - 2019-05-24
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/bulk_grades/__init__.py
+++ b/bulk_grades/__init__.py
@@ -4,6 +4,6 @@ Support for bulk scoring and grading.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = '0.1.3'
+__version__ = '0.1.4'
 
 default_app_config = 'bulk_grades.apps.BulkGradesConfig'  # pylint: disable=invalid-name

--- a/bulk_grades/api.py
+++ b/bulk_grades/api.py
@@ -281,7 +281,8 @@ class GradeCSVProcessor(DeferrableMixin, CSVProcessor):
                 grade = grades.get(subsection.location, None)
                 if grade:
                     row['grade-{}'.format(block_id)] = grade.earned_all
-                    row['previous-{}'.format(block_id)] = grade.override.earned_graded_override if grade.override else None
+                    row['previous-{}'.format(block_id)] = (
+                        grade.override.earned_graded_override if grade.override else None)
             yield row
 
 

--- a/bulk_grades/urls.py
+++ b/bulk_grades/urls.py
@@ -11,8 +11,13 @@ from . import views
 
 urlpatterns = [
     url(
-        r'bulk_grades/course/{}'.format(settings.COURSE_ID_PATTERN),
+        r'^bulk_grades/course/{}/$'.format(settings.COURSE_ID_PATTERN),
         views.GradeImportExport.as_view(),
         name='bulk_grades'
-    )
+    ),
+    url(
+        r'^bulk_grades/course/{}/history/$'.format(settings.COURSE_ID_PATTERN),
+        views.GradeOperationHistoryView.as_view(),
+        name='bulk_grades.history'
+    ),
 ]

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,10 +8,12 @@ amqp==1.4.9               # via kombu
 anyjson==0.3.3            # via kombu
 billiard==3.3.0.23        # via celery
 celery==3.1.26.post2      # via django-celery
-django-celery==3.3.0      # via super-csv
-django-crum==0.7.3        # via super-csv
+django-celery==3.3.0
+django-crum==0.7.3
 django-model-utils==3.2.0
-django==1.11.21
+django-rest-framework==0.1.0
+django==1.11.22
+djangorestframework==3.9.4  # via django-rest-framework
 edx-opaque-keys==1.0.1
 kombu==3.0.37             # via celery
 pbr==5.3.1                # via stevedore
@@ -19,4 +21,4 @@ pymongo==3.8.0            # via edx-opaque-keys
 pytz==2019.1              # via celery, django
 six==1.12.0               # via edx-opaque-keys, stevedore
 stevedore==1.30.1         # via edx-opaque-keys
-super-csv==0.3
+super-csv==0.5

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -14,6 +14,8 @@ backports.functools-lru-cache==1.5
 billiard==3.3.0.23
 caniusepython3==7.1.0
 celery==3.1.26.post2
+certifi==2019.6.16
+chardet==3.0.4
 click-log==0.3.2
 click==7.0
 code-annotations==0.3.2
@@ -21,12 +23,14 @@ codecov==2.0.15
 configparser==3.7.4
 contextlib2==0.5.5
 coverage==4.5.3
-diff-cover==2.2.0
+diff-cover==2.3.0
 distlib==0.2.9.post0
 django-celery==3.3.0
 django-crum==0.7.3
 django-model-utils==3.2.0
-django==1.11.21
+django-rest-framework==0.1.0
+django==1.11.22
+djangorestframework==3.9.4
 edx-i18n-tools==0.4.8
 edx-lint==1.3.0
 edx-opaque-keys==1.0.1
@@ -34,6 +38,7 @@ enum34==1.1.6
 filelock==3.0.12
 funcsigs==1.0.2
 futures==3.2.0 ; python_version == "2.7"
+idna==2.8
 importlib-metadata==0.18
 inflect==2.1.0            # via jinja2-pluralize
 isort==4.3.21
@@ -62,8 +67,8 @@ pylint==1.7.6
 pymongo==3.8.0
 pyparsing==2.4.0
 pytest-cov==2.7.1
-pytest-django==3.5.0
-pytest==4.6.3
+pytest-django==3.5.1
+pytest==4.6.4
 python-slugify==3.0.2
 pytz==2019.1
 pyyaml==5.1.1
@@ -73,11 +78,12 @@ singledispatch==3.4.0.3
 six==1.12.0
 snowballstemmer==1.9.0
 stevedore==1.30.1
-super-csv==0.3
+super-csv==0.5
 text-unidecode==1.2
 toml==0.10.0
 tox-battery==0.5.1
-tox==3.13.1
+tox==3.13.2
+urllib3==1.25.3
 virtualenv==16.6.1
 wcwidth==0.1.7
 wrapt==1.11.2

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -13,7 +13,8 @@ babel==2.7.0              # via sphinx
 billiard==3.3.0.23
 bleach==3.1.0             # via readme-renderer
 celery==3.1.26.post2
-chardet==3.0.4            # via doc8
+certifi==2019.6.16        # via requests
+chardet==3.0.4            # via doc8, requests
 click==7.0
 code-annotations==0.3.2
 configparser==3.7.4
@@ -22,12 +23,15 @@ coverage==4.5.3
 django-celery==3.3.0
 django-crum==0.7.3
 django-model-utils==3.2.0
-django==1.11.21
+django-rest-framework==0.1.0
+django==1.11.22
+djangorestframework==3.9.4
 doc8==0.8.0
 docutils==0.14            # via doc8, readme-renderer, restructuredtext-lint, sphinx
 edx-opaque-keys==1.0.1
 edx-sphinx-theme==1.5.0
 funcsigs==1.0.2
+idna==2.8                 # via requests
 imagesize==1.1.0          # via sphinx
 importlib-metadata==0.18
 jinja2==2.10.1
@@ -43,8 +47,8 @@ pygments==2.4.2           # via readme-renderer, sphinx
 pymongo==3.8.0
 pyparsing==2.4.0
 pytest-cov==2.7.1
-pytest-django==3.5.0
-pytest==4.6.3
+pytest-django==3.5.1
+pytest==4.6.4
 python-slugify==3.0.2
 pytz==2019.1
 pyyaml==5.1.1
@@ -57,9 +61,10 @@ snowballstemmer==1.9.0    # via sphinx
 sphinx==1.8.5
 sphinxcontrib-websupport==1.1.2  # via sphinx
 stevedore==1.30.1
-super-csv==0.3
+super-csv==0.5
 text-unidecode==1.2
 typing==3.7.4             # via sphinx
+urllib3==1.25.3           # via requests
 wcwidth==0.1.7
 webencodings==0.5.1       # via bleach
 zipp==0.5.1

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -14,6 +14,8 @@ backports.functools-lru-cache==1.5  # via astroid, caniusepython3, isort, pylint
 billiard==3.3.0.23
 caniusepython3==7.1.0
 celery==3.1.26.post2
+certifi==2019.6.16        # via requests
+chardet==3.0.4            # via requests
 click-log==0.3.2          # via edx-lint
 click==7.0
 code-annotations==0.3.2
@@ -24,12 +26,15 @@ distlib==0.2.9.post0      # via caniusepython3
 django-celery==3.3.0
 django-crum==0.7.3
 django-model-utils==3.2.0
-django==1.11.21
+django-rest-framework==0.1.0
+django==1.11.22
+djangorestframework==3.9.4
 edx-lint==1.3.0
 edx-opaque-keys==1.0.1
 enum34==1.1.6             # via astroid
 funcsigs==1.0.2
 futures==3.2.0 ; python_version == "2.7"  # via caniusepython3, isort
+idna==2.8                 # via requests
 importlib-metadata==0.18
 isort==4.3.21
 jinja2==2.10.1
@@ -52,8 +57,8 @@ pylint==1.7.6             # via edx-lint, pylint-celery, pylint-django, pylint-p
 pymongo==3.8.0
 pyparsing==2.4.0
 pytest-cov==2.7.1
-pytest-django==3.5.0
-pytest==4.6.3
+pytest-django==3.5.1
+pytest==4.6.4
 python-slugify==3.0.2
 pytz==2019.1
 pyyaml==5.1.1
@@ -63,8 +68,9 @@ singledispatch==3.4.0.3   # via astroid, pylint
 six==1.12.0
 snowballstemmer==1.9.0    # via pydocstyle
 stevedore==1.30.1
-super-csv==0.3
+super-csv==0.5
 text-unidecode==1.2
+urllib3==1.25.3           # via requests
 wcwidth==0.1.7
 wrapt==1.11.2             # via astroid
 zipp==0.5.1

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -18,6 +18,8 @@ coverage==4.5.3           # via pytest-cov
 django-celery==3.3.0
 django-crum==0.7.3
 django-model-utils==3.2.0
+django-rest-framework==0.1.0
+djangorestframework==3.9.4
 edx-opaque-keys==1.0.1
 funcsigs==1.0.2           # via pytest
 importlib-metadata==0.18  # via pluggy, pytest
@@ -33,15 +35,15 @@ py==1.8.0                 # via pytest
 pymongo==3.8.0
 pyparsing==2.4.0          # via packaging
 pytest-cov==2.7.1
-pytest-django==3.5.0
-pytest==4.6.3             # via pytest-cov, pytest-django
+pytest-django==3.5.1
+pytest==4.6.4             # via pytest-cov, pytest-django
 python-slugify==3.0.2     # via code-annotations
 pytz==2019.1
 pyyaml==5.1.1             # via code-annotations
 scandir==1.10.0           # via pathlib2
 six==1.12.0
 stevedore==1.30.1
-super-csv==0.3
+super-csv==0.5
 text-unidecode==1.2       # via python-slugify
 wcwidth==0.1.7            # via pytest
 zipp==0.5.1               # via importlib-metadata

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -4,11 +4,14 @@
 #
 #    make upgrade
 #
+certifi==2019.6.16        # via requests
+chardet==3.0.4            # via requests
 codecov==2.0.15
 configparser==3.7.4       # via importlib-metadata
 contextlib2==0.5.5        # via importlib-metadata
 coverage==4.5.3           # via codecov
 filelock==3.0.12          # via tox
+idna==2.8                 # via requests
 importlib-metadata==0.18  # via pluggy, tox
 packaging==19.0           # via tox
 pathlib2==2.3.4           # via importlib-metadata
@@ -20,6 +23,7 @@ scandir==1.10.0           # via pathlib2
 six==1.12.0               # via packaging, pathlib2, tox
 toml==0.10.0              # via tox
 tox-battery==0.5.1
-tox==3.13.1
+tox==3.13.2
+urllib3==1.25.3           # via requests
 virtualenv==16.6.1        # via tox
 zipp==0.5.1               # via importlib-metadata

--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,14 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-# pylint: disable=open-builtin,native-string
 """
 Package metadata for bulk_grades.
 """
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import, print_function, unicode_literals
 
 import os
 import re
 import sys
+from io import open as open_as_of_py3
 
 from setuptools import setup
 
@@ -18,7 +18,7 @@ def get_version(*file_paths):
     Extract the version string from the file at the given relative path fragments.
     """
     filename = os.path.join(os.path.dirname(__file__), *file_paths)
-    version_file = open(filename).read()
+    version_file = open_as_of_py3(filename).read()
     version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
                               version_file, re.M)
     if version_match:
@@ -36,7 +36,7 @@ def load_requirements(*requirements_paths):
     requirements = set()
     for path in requirements_paths:
         requirements.update(
-            line.split('#')[0].strip() for line in open(path).readlines()
+            line.split('#')[0].strip() for line in open_as_of_py3(path).readlines()
             if is_requirement(line.strip())
         )
     return list(requirements)
@@ -60,8 +60,8 @@ if sys.argv[-1] == 'tag':
     os.system("git push --tags")
     sys.exit()
 
-README = open(os.path.join(os.path.dirname(__file__), 'README.rst')).read()
-CHANGELOG = open(os.path.join(os.path.dirname(__file__), 'CHANGELOG.rst')).read()
+README = open_as_of_py3(os.path.join(os.path.dirname(__file__), 'README.rst')).read()
+CHANGELOG = open_as_of_py3(os.path.join(os.path.dirname(__file__), 'CHANGELOG.rst')).read()
 
 setup(
     name='edx-bulk-grades',

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -16,6 +16,9 @@ from student.models import CourseEnrollment, Profile, ProgramCourseEnrollment
 
 
 class BaseTests(TestCase):
+    """
+    Common setup functionality for all test cases
+    """
     def setUp(self):
         super(BaseTests, self).setUp()
         self.learner = User.objects.create(username='student@example.com')
@@ -47,7 +50,13 @@ class TestApi(BaseTests):
 
 
 class TestScoreProcessor(BaseTests):
+    """
+    Tests exercising the processing performed by ScoreCSVProcessor
+    """
     def _get_row(self, **kwargs):
+        """
+        Get a properly shaped row
+        """
         row = {
             'block_id': self.block_id,
             'points': 0,
@@ -109,6 +118,9 @@ class TestScoreProcessor(BaseTests):
 
 
 class TestGradeProcessor(BaseTests):
+    """
+    Tests exercising the processing performed by GradeCSVProcessor
+    """
     def test_export(self):
         self._make_enrollments()
         processor = api.GradeCSVProcessor(course_id=self.course_id)

--- a/tox.ini
+++ b/tox.ini
@@ -30,7 +30,6 @@ match-dir = (?!migrations)
 
 [pytest]
 DJANGO_SETTINGS_MODULE = test_settings
-PYTHONPATH = mock_apps/
 addopts = --cov bulk_grades --cov-report term-missing --cov-report xml
 norecursedirs = .* docs requirements
 
@@ -62,8 +61,6 @@ commands =
     python setup.py check --restructuredtext --strict
 
 [testenv:quality]
-setenv =
-    PYTHONPATH = mock_apps/
 whitelist_externals =
     make
     rm


### PR DESCRIPTION
**Description:** Fixes bug

**JIRA:** Fixes are blocking for EDUCATOR-4367 

**Dependencies:** https://github.com/edx/super-csv/pull/6

**Testing instructions:**
Now that gradebook has import functionality, we can test there
1. Create a course with graded subsection(s) & add a masters track to it (http://localhost:18000/admin/course_modes/coursemode/)
2. enroll some learner in the course
3. View gradebook page for that course (http://localhost:1994/<your_course_key>) and switch to bulk management tab
4. Export grade CSV
5. Change a grade in the csv
6. Import the csv
 

**Reviewers:**
- [ ] @davestgermain

**Merge checklist:**
- [ ] All reviewers approved
- [x] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [x] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)