### PR TITLE
Add subsection filter to grade export.

### DIFF
--- a/bulk_grades/api.py
+++ b/bulk_grades/api.py
@@ -194,7 +194,10 @@ class GradeCSVProcessor(DeferrableMixin, CSVProcessor):
         self.track = self.cohort = self._user = None
         super(GradeCSVProcessor, self).__init__(**kwargs)
         self._course_key = CourseKey.from_string(self.course_id)
-        self._subsections = self._get_graded_subsections(self._course_key)
+        self._subsections = self._get_graded_subsections(
+            self._course_key,
+            filter_subsection=kwargs.get('subsection', None)
+        )
         self._users_seen = set()
 
     def get_unique_path(self):
@@ -203,13 +206,18 @@ class GradeCSVProcessor(DeferrableMixin, CSVProcessor):
         """
         return self.course_id
 
-    def _get_graded_subsections(self, course_id):
+    def _get_graded_subsections(self, course_id, filter_subsection=None):
         """
         Return list of graded subsections.
+
+        If filter_subsection (block ID) is set, return only that subsection.
         """
         subsections = {}
         for subsection in grades_api.graded_subsections_for_course_id(course_id):
-            short_block_id = subsection.location.block_id[:8]
+            block_id = text_type(subsection.location.block_id)
+            if filter_subsection and block_id != filter_subsection:
+                continue
+            short_block_id = block_id[:8]
             if short_block_id not in subsections:
                 for key in ('name', 'grade', 'previous', 'new_grade'):
                     self.columns.append('{}-{}'.format(key, short_block_id))

--- a/bulk_grades/views.py
+++ b/bulk_grades/views.py
@@ -37,13 +37,19 @@ class GradeImportExport(View):
                                                   course_id=course_id,
                                                   _user=request.user,
                                                   track=request.GET.get('track'),
-                                                  cohort=request.GET.get('cohort')
+                                                  cohort=request.GET.get('cohort'),
+                                                  subsection=request.GET.get('subsection'),
                                                 )
         return super(GradeImportExport, self).dispatch(request, course_id, *args, **kwargs)
 
     def get(self, request, course_id, *args, **kwargs):  # pylint: disable=unused-argument
         """
         Export grades in CSV format.
+
+        GET arguments:
+        track: name of enrollment mode
+        cohort: name of cohort
+        subsection: block id of graded subsection
         """
         iterator = self.processor.get_iterator(error_data=bool(self.operation_id))
         filename = [course_id]


### PR DESCRIPTION
To export grades for a single subsection, pass `subsection=a01bc2` (block ID) to the export endpoint.

