### PR TITLE
Correct data source for gradebook grades

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,10 @@ Unreleased
 
 *
 
+[0.5.2] - 2019-08-15
+~~~~~~~~~~~~~~~~~~~~
+* Bring datasource for grade information inline with what the rest of gradebook uses
+
 [0.4.4] - 2019-08-13
 ~~~~~~~~~~~~~~~~~~~~
 Add ability to filter by course grade, provided as a percentage to the endpoint.

--- a/bulk_grades/__init__.py
+++ b/bulk_grades/__init__.py
@@ -4,6 +4,6 @@ Support for bulk scoring and grading.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = '0.5.1'
+__version__ = '0.5.2'
 
 default_app_config = 'bulk_grades.apps.BulkGradesConfig'  # pylint: disable=invalid-name

--- a/bulk_grades/api.py
+++ b/bulk_grades/api.py
@@ -293,7 +293,7 @@ class GradeCSVProcessor(DeferrableMixin, CSVProcessor):
                 row['course_id'],
                 row['block_id'],
                 overrider=self._user,
-                earned_all=row['new_grade'],
+                earned_graded=row['new_grade'],
                 feature='grade-import'
         )
         return True, None
@@ -324,10 +324,10 @@ class GradeCSVProcessor(DeferrableMixin, CSVProcessor):
                 if not subsection_grade:
                     continue
                 try:
-                    effective_grade = (subsection_grade.override.earned_all_override
-                                       / subsection_grade.override.possible_all_override) * 100
+                    effective_grade = (subsection_grade.override.earned_graded_override
+                                       / subsection_grade.override.possible_graded_override) * 100
                 except AttributeError:
-                    effective_grade = (subsection_grade.earned_all / subsection_grade.possible_all) * 100
+                    effective_grade = (subsection_grade.earned_graded / subsection_grade.possible_graded) * 100
                 if (self.subsection_grade_min and effective_grade < self.subsection_grade_min) or (
                         self.subsection_grade_max and effective_grade > self.subsection_grade_max):
                     continue
@@ -343,9 +343,9 @@ class GradeCSVProcessor(DeferrableMixin, CSVProcessor):
                 row['name-{}'.format(block_id)] = display_name
                 grade = grades.get(subsection.location, None)
                 if grade:
-                    row['grade-{}'.format(block_id)] = grade.earned_all
+                    row['grade-{}'.format(block_id)] = grade.earned_graded
                     try:
-                        row['previous-{}'.format(block_id)] = grade.override.earned_all_override
+                        row['previous-{}'.format(block_id)] = grade.override.earned_graded_override
                     except AttributeError:
                         row['previous-{}'.format(block_id)] = None
             yield row
@@ -428,7 +428,7 @@ class InterventionCSVProcessor(CSVProcessor):
                 row['name-{}'.format(block_id)] = display_name
                 grade = grades.get(subsection.location, None)
                 if grade:
-                    row['grade-{}'.format(block_id)] = grade.earned_all
+                    row['grade-{}'.format(block_id)] = grade.earned_graded
             yield row
 
 

--- a/mock_apps/lms/djangoapps/grades/api.py
+++ b/mock_apps/lms/djangoapps/grades/api.py
@@ -15,9 +15,9 @@ class Subsection(object):
 
 class Grade(object):
     def __init__(self):
-        self.earned_all = 1
+        self.earned_graded = 1
         self.override = None
-        self.possible_all = 1
+        self.possible_graded = 1
 
 
 def prefetch_course_and_subsection_grades(course_id, users):


### PR DESCRIPTION
**Description:** Previously CSV was writing/reading the _all grade fields, where we
should've been using exclusively the _graded fields as that's what
preexisting gradebook functionality writes/reads.

**Reviewers:**
- [x] @davestgermain 

**Merge checklist:**
- [x] All reviewers approved
- [x] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [x] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** This sort of change isn't super helpful without having clarity among members of the team about the semantics of the fields & why the `_graded` ones are more correct. I'll try to address this in meetings, but may miss some folks.