### PR TITLE
Remove permission checks which are preventing access to Gradebook

### DIFF
--- a/bulk_grades/__init__.py
+++ b/bulk_grades/__init__.py
@@ -4,6 +4,6 @@ Support for bulk scoring and grading.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = '0.5.3'
+__version__ = '0.5.4'
 
 default_app_config = 'bulk_grades.apps.BulkGradesConfig'  # pylint: disable=invalid-name

--- a/bulk_grades/views.py
+++ b/bulk_grades/views.py
@@ -44,8 +44,6 @@ class GradeOnlyExport(View):
         """
         Dispatch django request.
         """
-        if not (request.user.is_staff or request.user.has_perm('bulk_grades', course_id)):
-            return HttpResponseForbidden('Not Staff')
         self.initialize_processor(request, course_id)
         return super(GradeOnlyExport, self).dispatch(request, course_id, *args, **kwargs)
 
@@ -155,14 +153,6 @@ class GradeOperationHistoryView(View):
         )
         history = processor.get_committed_history()
         return HttpResponse(json.dumps(history), content_type='application/json')
-
-    def dispatch(self, request, course_id, *args, **kwargs):  # pylint: disable=arguments-differ
-        """
-        General set-up method for all handler messages in this view.
-        """
-        if not (request.user.is_staff or request.user.has_perm('bulk_grades', course_id)):
-            return HttpResponseForbidden('Not Staff')
-        return super(GradeOperationHistoryView, self).dispatch(request, course_id, *args, **kwargs)
 
 
 class InterventionsExport(GradeOnlyExport):


### PR DESCRIPTION
JIRA:PROD-553

**Description:** Rips out permissions which were there prospectively; we can add them all back in once discussions have landed about what rules should be applied. ~~For right now we don't expect an impact (nor traffic on them) since the corresponding UI elements will show only for Master's courses, of which there are none.~~ EDIT: there are masters courses, and those are the only ones broken in this way.

**JIRA:** https://openedx.atlassian.net/browse/PROD-553

**Reviewers:**
- [ ] @davestgermain 

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)