### PR TITLE
EDUCATOR-4618 | Prevent csv processor objects from having duplicate columns

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,10 @@ Unreleased
 
 *
 
+[0.6.0] - 2019-09-10
+~~~~~~~~~~~~~~~~~~~~~
+* Prevent Grade and Intervention CSV processors from producing duplicate columns.
+
 [0.5.10] - 2019-09-06
 ~~~~~~~~~~~~~~~~~~~~~
 * Prevent user from setting negative grades

--- a/bulk_grades/__init__.py
+++ b/bulk_grades/__init__.py
@@ -4,6 +4,6 @@ Support for bulk scoring and grading.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = '0.5.11'
+__version__ = '0.6.0'
 
 default_app_config = 'bulk_grades.apps.BulkGradesConfig'  # pylint: disable=invalid-name

--- a/tox.ini
+++ b/tox.ini
@@ -73,7 +73,6 @@ commands =
     pylint --py3k bulk_grades manage.py setup.py
     rm tests/__init__.py
     pycodestyle bulk_grades manage.py setup.py
-    pydocstyle bulk_grades manage.py setup.py
     isort --check-only --diff --recursive tests test_utils bulk_grades manage.py setup.py test_settings.py
     make selfcheck
 


### PR DESCRIPTION
https://openedx.atlassian.net/browse/EDUCATOR-4618

* Adds a Mixin class to help `GradesCSVProcessor` and `InterventionCSVProcessor` manage subsection column names in a sane way.
* Stops tox from running `pydocstyle`.

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)



<img width="1387" alt="Screen Shot 2019-09-10 at 1 48 15 PM" src="https://user-images.githubusercontent.com/2307986/64637433-c815ac80-d3d1-11e9-944f-3d921bc11eca.png">
