### PR TITLE
EDUCATOR-4638 add comment to bulk grade upload

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,7 @@ Unreleased
 [0.6.1] - 2019-09-17
 ~~~~~~~~~~~~~~~~~~~~~
 * Call grades api with `comment` when doing bulk upload
+* Add `user_id` field to GradeCSVProcessor to fix bulk_upload history entries
 
 [0.6.0] - 2019-09-10
 ~~~~~~~~~~~~~~~~~~~~~

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,10 @@ Unreleased
 
 *
 
+[0.6.1] - 2019-09-17
+~~~~~~~~~~~~~~~~~~~~~
+* Call grades api with `comment` when doing bulk upload
+
 [0.6.0] - 2019-09-10
 ~~~~~~~~~~~~~~~~~~~~~
 * Prevent Grade and Intervention CSV processors from producing duplicate columns.

--- a/bulk_grades/__init__.py
+++ b/bulk_grades/__init__.py
@@ -4,6 +4,6 @@ Support for bulk scoring and grading.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = '0.6.0'
+__version__ = '0.6.1'
 
 default_app_config = 'bulk_grades.apps.BulkGradesConfig'  # pylint: disable=invalid-name

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,22 +8,22 @@ amqp==1.4.9               # via kombu
 anyjson==0.3.3            # via kombu
 billiard==3.3.0.23        # via celery
 celery==3.1.26.post2      # via django-celery
-certifi==2019.6.16        # via requests
+certifi==2019.9.11        # via requests
 chardet==3.0.4            # via requests
 django-celery==3.3.1      # via super-csv
 django-crum==0.7.3        # via super-csv
 django-model-utils==3.2.0
-django==1.11.23
+django==1.11.24
 djangorestframework==3.9.4  # via super-csv
-edx-opaque-keys==1.0.1
+edx-opaque-keys==2.0.0
 idna==2.8                 # via requests
 kombu==3.0.37             # via celery
-pbr==5.4.2                # via stevedore
+pbr==5.4.3                # via stevedore
 pymongo==3.9.0            # via edx-opaque-keys
 pytz==2019.2              # via celery, django
 requests==2.22.0
 six==1.12.0               # via edx-opaque-keys, stevedore
 slumber==0.7.1
-stevedore==1.30.1         # via edx-opaque-keys
-super-csv==0.9.1
+stevedore==1.31.0         # via edx-opaque-keys
+super-csv==0.9.2
 urllib3==1.25.3           # via requests

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -14,13 +14,13 @@ backports.functools-lru-cache==1.5
 billiard==3.3.0.23
 caniusepython3==7.1.0
 celery==3.1.26.post2
-certifi==2019.6.16
+certifi==2019.9.11
 chardet==3.0.4
 click-log==0.3.2
 click==7.0
 code-annotations==0.3.2
 codecov==2.0.15
-configparser==3.8.1
+configparser==4.0.2
 contextlib2==0.5.5
 coverage==4.5.4
 diff-cover==2.3.0
@@ -28,23 +28,23 @@ distlib==0.2.9.post0
 django-celery==3.3.1
 django-crum==0.7.3
 django-model-utils==3.2.0
-django==1.11.23
+django==1.11.24
 djangorestframework==3.9.4
 edx-i18n-tools==0.4.8
 edx-lint==1.3.0
-edx-opaque-keys==1.0.1
+edx-opaque-keys==2.0.0
 enum34==1.1.6
 filelock==3.0.12
 funcsigs==1.0.2
 futures==3.3.0 ; python_version == "2.7"
 idna==2.8
-importlib-metadata==0.19
+importlib-metadata==0.23
 inflect==2.1.0            # via jinja2-pluralize
 isort==4.3.21
 jinja2-pluralize==0.3.0   # via diff-cover
 jinja2==2.10.1
 kombu==3.0.37
-lazy-object-proxy==1.4.1
+lazy-object-proxy==1.4.2
 markupsafe==1.1.1
 mccabe==0.6.1
 mock==3.0.5
@@ -52,9 +52,9 @@ more-itertools==5.0.0
 packaging==19.1
 path.py==11.5.2           # via edx-i18n-tools
 pathlib2==2.3.4
-pbr==5.4.2
-pip-tools==4.0.0
-pluggy==0.12.0
+pbr==5.4.3
+pip-tools==4.1.0
+pluggy==0.13.0
 polib==1.1.0              # via edx-i18n-tools
 py==1.8.0
 pycodestyle==2.5.0
@@ -77,18 +77,18 @@ scandir==1.10.0
 singledispatch==3.4.0.3
 six==1.12.0
 slumber==0.7.1
-snowballstemmer==1.9.0
-stevedore==1.30.1
-super-csv==0.9.1
+snowballstemmer==1.9.1
+stevedore==1.31.0
+super-csv==0.9.2
 text-unidecode==1.2
 toml==0.10.0
 tox-battery==0.5.1
-tox==3.13.2
+tox==3.14.0
 urllib3==1.25.3
-virtualenv==16.7.3
+virtualenv==16.7.5
 wcwidth==0.1.7
 wrapt==1.11.2
-zipp==0.5.2
+zipp==0.6.0
 
 # The following packages are considered to be unsafe in a requirements file:
-# setuptools==41.1.0        # via caniusepython3
+# setuptools==41.2.0        # via caniusepython3

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -13,26 +13,26 @@ babel==2.7.0              # via sphinx
 billiard==3.3.0.23
 bleach==3.1.0             # via readme-renderer
 celery==3.1.26.post2
-certifi==2019.6.16
+certifi==2019.9.11
 chardet==3.0.4
 click==7.0
 code-annotations==0.3.2
-configparser==3.8.1
+configparser==4.0.2
 contextlib2==0.5.5
 coverage==4.5.4
 django-celery==3.3.1
 django-crum==0.7.3
 django-model-utils==3.2.0
-django==1.11.23
+django==1.11.24
 djangorestframework==3.9.4
 doc8==0.8.0
 docutils==0.15.2          # via doc8, readme-renderer, restructuredtext-lint, sphinx
-edx-opaque-keys==1.0.1
+edx-opaque-keys==2.0.0
 edx-sphinx-theme==1.5.0
 funcsigs==1.0.2
 idna==2.8
 imagesize==1.1.0          # via sphinx
-importlib-metadata==0.19
+importlib-metadata==0.23
 jinja2==2.10.1
 kombu==3.0.37
 markupsafe==1.1.1
@@ -40,8 +40,8 @@ mock==3.0.5
 more-itertools==5.0.0
 packaging==19.1
 pathlib2==2.3.4
-pbr==5.4.2
-pluggy==0.12.0
+pbr==5.4.3
+pluggy==0.13.0
 py==1.8.0
 pygments==2.4.2           # via readme-renderer, sphinx
 pymongo==3.9.0
@@ -58,17 +58,17 @@ restructuredtext-lint==1.3.0  # via doc8
 scandir==1.10.0
 six==1.12.0
 slumber==0.7.1
-snowballstemmer==1.9.0    # via sphinx
+snowballstemmer==1.9.1    # via sphinx
 sphinx==1.8.5
 sphinxcontrib-websupport==1.1.2  # via sphinx
-stevedore==1.30.1
-super-csv==0.9.1
+stevedore==1.31.0
+super-csv==0.9.2
 text-unidecode==1.2
-typing==3.7.4             # via sphinx
+typing==3.7.4.1           # via sphinx
 urllib3==1.25.3
 wcwidth==0.1.7
 webencodings==0.5.1       # via bleach
-zipp==0.5.2
+zipp==0.6.0
 
 # The following packages are considered to be unsafe in a requirements file:
-# setuptools==41.1.0        # via sphinx
+# setuptools==41.2.0        # via sphinx

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -5,5 +5,5 @@
 #    make upgrade
 #
 click==7.0                # via pip-tools
-pip-tools==4.0.0
+pip-tools==4.1.0
 six==1.12.0               # via pip-tools

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -14,39 +14,39 @@ backports.functools-lru-cache==1.5  # via astroid, caniusepython3, isort, pylint
 billiard==3.3.0.23
 caniusepython3==7.1.0
 celery==3.1.26.post2
-certifi==2019.6.16
+certifi==2019.9.11
 chardet==3.0.4
 click-log==0.3.2          # via edx-lint
 click==7.0
 code-annotations==0.3.2
-configparser==3.8.1
+configparser==4.0.2
 contextlib2==0.5.5
 coverage==4.5.4
 distlib==0.2.9.post0      # via caniusepython3
 django-celery==3.3.1
 django-crum==0.7.3
 django-model-utils==3.2.0
-django==1.11.23
+django==1.11.24
 djangorestframework==3.9.4
 edx-lint==1.3.0
-edx-opaque-keys==1.0.1
+edx-opaque-keys==2.0.0
 enum34==1.1.6             # via astroid
 funcsigs==1.0.2
 futures==3.3.0 ; python_version == "2.7"  # via caniusepython3, isort
 idna==2.8
-importlib-metadata==0.19
+importlib-metadata==0.23
 isort==4.3.21
 jinja2==2.10.1
 kombu==3.0.37
-lazy-object-proxy==1.4.1  # via astroid
+lazy-object-proxy==1.4.2  # via astroid
 markupsafe==1.1.1
 mccabe==0.6.1             # via pylint
 mock==3.0.5
 more-itertools==5.0.0
 packaging==19.1
 pathlib2==2.3.4
-pbr==5.4.2
-pluggy==0.12.0
+pbr==5.4.3
+pluggy==0.13.0
 py==1.8.0
 pycodestyle==2.5.0
 pydocstyle==3.0.0
@@ -67,14 +67,14 @@ scandir==1.10.0
 singledispatch==3.4.0.3   # via astroid, pylint
 six==1.12.0
 slumber==0.7.1
-snowballstemmer==1.9.0    # via pydocstyle
-stevedore==1.30.1
-super-csv==0.9.1
+snowballstemmer==1.9.1    # via pydocstyle
+stevedore==1.31.0
+super-csv==0.9.2
 text-unidecode==1.2
 urllib3==1.25.3
 wcwidth==0.1.7
 wrapt==1.11.2             # via astroid
-zipp==0.5.2
+zipp==0.6.0
 
 # The following packages are considered to be unsafe in a requirements file:
-# setuptools==41.1.0        # via caniusepython3
+# setuptools==41.2.0        # via caniusepython3

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -10,30 +10,30 @@ atomicwrites==1.3.0       # via pytest
 attrs==19.1.0             # via packaging, pytest
 billiard==3.3.0.23
 celery==3.1.26.post2
-certifi==2019.6.16
+certifi==2019.9.11
 chardet==3.0.4
 click==7.0                # via code-annotations
 code-annotations==0.3.2
-configparser==3.8.1       # via importlib-metadata
+configparser==4.0.2       # via importlib-metadata
 contextlib2==0.5.5        # via importlib-metadata
 coverage==4.5.4           # via pytest-cov
 django-celery==3.3.1
 django-crum==0.7.3
 django-model-utils==3.2.0
 djangorestframework==3.9.4
-edx-opaque-keys==1.0.1
+edx-opaque-keys==2.0.0
 funcsigs==1.0.2           # via mock, pytest
 idna==2.8
-importlib-metadata==0.19  # via pluggy, pytest
+importlib-metadata==0.23  # via pluggy, pytest
 jinja2==2.10.1            # via code-annotations
 kombu==3.0.37
 markupsafe==1.1.1         # via jinja2
 mock==3.0.5
-more-itertools==5.0.0     # via pytest
+more-itertools==5.0.0     # via pytest, zipp
 packaging==19.1           # via pytest
 pathlib2==2.3.4           # via importlib-metadata, pytest, pytest-django
-pbr==5.4.2
-pluggy==0.12.0            # via pytest
+pbr==5.4.3
+pluggy==0.13.0            # via pytest
 py==1.8.0                 # via pytest
 pymongo==3.9.0
 pyparsing==2.4.2          # via packaging
@@ -47,9 +47,9 @@ requests==2.22.0
 scandir==1.10.0           # via pathlib2
 six==1.12.0
 slumber==0.7.1
-stevedore==1.30.1
-super-csv==0.9.1
+stevedore==1.31.0
+super-csv==0.9.2
 text-unidecode==1.2       # via python-slugify
 urllib3==1.25.3
 wcwidth==0.1.7            # via pytest
-zipp==0.5.2               # via importlib-metadata
+zipp==0.6.0               # via importlib-metadata

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -5,18 +5,19 @@
 #    make upgrade
 #
 attrs==19.1.0             # via packaging
-certifi==2019.6.16        # via requests
+certifi==2019.9.11        # via requests
 chardet==3.0.4            # via requests
 codecov==2.0.15
-configparser==3.8.1       # via importlib-metadata
+configparser==4.0.2       # via importlib-metadata
 contextlib2==0.5.5        # via importlib-metadata
 coverage==4.5.4           # via codecov
 filelock==3.0.12          # via tox
 idna==2.8                 # via requests
-importlib-metadata==0.19  # via pluggy, tox
+importlib-metadata==0.23  # via pluggy, tox
+more-itertools==5.0.0     # via zipp
 packaging==19.1           # via tox
 pathlib2==2.3.4           # via importlib-metadata
-pluggy==0.12.0            # via tox
+pluggy==0.13.0            # via tox
 py==1.8.0                 # via tox
 pyparsing==2.4.2          # via packaging
 requests==2.22.0          # via codecov
@@ -24,7 +25,7 @@ scandir==1.10.0           # via pathlib2
 six==1.12.0               # via packaging, pathlib2, tox
 toml==0.10.0              # via tox
 tox-battery==0.5.1
-tox==3.13.2
+tox==3.14.0
 urllib3==1.25.3           # via requests
-virtualenv==16.7.3        # via tox
-zipp==0.5.2               # via importlib-metadata
+virtualenv==16.7.5        # via tox
+zipp==0.6.0               # via importlib-metadata


### PR DESCRIPTION
**Description:** Pass a  `comment` to `grades_api.override_subsection_grade` when doing bulk grade upload, which will show up as 'Reason' in the override history view.

Also, add a user_id field to gradecsvprocessor to allow super_csv to track user if it loses the request context

**JIRA:** [EDUCATOR-4638](https://openedx.atlassian.net/browse/EDUCATOR-4638) 

**Reviewers:**
@edx/masters-devs 
- [ ] tag reviewer 
- [ ] tag reviewer 

**Merge checklist:**
- [x] All reviewers approved
- [x] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [x] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)
