### PR TITLE
EDUCATOR-4638 | Make sure GradeCSVProcessor.user_id is not null.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,10 @@ Unreleased
 ~~~~~~~~~~
 *
 
+[0.6.3] - 2019-09-24
+~~~~~~~~~~~~~~~~~~~~~
+* Upgrade super-csv to 0.9.4, make sure to pass ``user_id`` to GradeCSVProcessor.__init__().
+
 [0.6.2] - 2019-09-23
 ~~~~~~~~~~~~~~~~~~~~~
 * Upgrade super-csv to 0.9.3

--- a/bulk_grades/__init__.py
+++ b/bulk_grades/__init__.py
@@ -4,6 +4,6 @@ Support for bulk scoring and grading.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = '0.6.2'
+__version__ = '0.6.3'
 
 default_app_config = 'bulk_grades.apps.BulkGradesConfig'  # pylint: disable=invalid-name

--- a/bulk_grades/api.py
+++ b/bulk_grades/api.py
@@ -270,7 +270,7 @@ class GradeCSVProcessor(DeferrableMixin, GradedSubsectionMixin, CSVProcessor):
         self.user_id = None
 
         # The CSVProcessor.__init__ method will set attributes on self
-        # from items in kwargs, so this super().__init__() call will
+        # from items in kwargs, so this super().__init__() call can
         # override any attribute values assigned above.
         super(GradeCSVProcessor, self).__init__(**kwargs)
 
@@ -290,6 +290,13 @@ class GradeCSVProcessor(DeferrableMixin, GradedSubsectionMixin, CSVProcessor):
     def _user(self):
         if self.user_id:
             return get_user_model().objects.get(id=self.user_id)
+
+    def save(self, operation_name=None, operating_user=None):
+        """
+        Saves the operation state for this processor, including the user
+        who is performing the operation.
+        """
+        super(GradeCSVProcessor, self).save(operating_user=self._user)
 
     def get_unique_path(self):
         """

--- a/bulk_grades/views.py
+++ b/bulk_grades/views.py
@@ -124,7 +124,7 @@ class GradeImportExport(GradeOnlyExport):
             course_grade_max = request.GET.get('courseGradeMax')
             self.processor = api.GradeCSVProcessor(
                 course_id=course_id,
-                _user=request.user,
+                user_id=request.user.id,
                 track=request.GET.get('track'),
                 cohort=request.GET.get('cohort'),
                 subsection=request.GET.get('assignment'),

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -25,5 +25,5 @@ requests==2.22.0
 six==1.12.0               # via edx-opaque-keys, stevedore
 slumber==0.7.1
 stevedore==1.31.0         # via edx-opaque-keys
-super-csv==0.9.3
+super-csv==0.9.4
 urllib3==1.25.3           # via requests

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -79,7 +79,7 @@ six==1.12.0
 slumber==0.7.1
 snowballstemmer==1.9.1
 stevedore==1.31.0
-super-csv==0.9.3
+super-csv==0.9.4
 text-unidecode==1.2
 toml==0.10.0
 tox-battery==0.5.1

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -62,7 +62,7 @@ snowballstemmer==1.9.1    # via sphinx
 sphinx==1.8.5
 sphinxcontrib-websupport==1.1.2  # via sphinx
 stevedore==1.31.0
-super-csv==0.9.3
+super-csv==0.9.4
 text-unidecode==1.2
 typing==3.7.4.1           # via sphinx
 urllib3==1.25.3

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -69,7 +69,7 @@ six==1.12.0
 slumber==0.7.1
 snowballstemmer==1.9.1    # via pydocstyle
 stevedore==1.31.0
-super-csv==0.9.3
+super-csv==0.9.4
 text-unidecode==1.2
 urllib3==1.25.3
 wcwidth==0.1.7

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -48,7 +48,7 @@ scandir==1.10.0           # via pathlib2
 six==1.12.0
 slumber==0.7.1
 stevedore==1.31.0
-super-csv==0.9.3
+super-csv==0.9.4
 text-unidecode==1.2       # via python-slugify
 urllib3==1.25.3
 wcwidth==0.1.7            # via pytest


### PR DESCRIPTION
**Description:**
The `GradeCSVProcessor.user_id` attribute was always null - we initiated the `_user` attribute instead.
Depends on https://github.com/edx/super-csv/pull/20

**JIRA:**
https://openedx.atlassian.net/browse/EDUCATOR-4638

**Merge checklist:**
- [x] Update super-csv requirements.
- [x] All reviewers approved
- [x] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)
