### PR TITLE
EDUCATOR-4821 | Account for cases where no score-overrider exists.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,10 @@ Unreleased
 ~~~~~~~~~~
 *
 
+[0.6.5] - 2019-12-05
+~~~~~~~~~~~~~~~~~~~~~
+* In ``get_scores()``, account for case where no ``ScoreOverrider`` exists.
+
 [0.6.4] - 2019-09-24
 ~~~~~~~~~~~~~~~~~~~~~
 * ``GradeCSVProcessor.save()`` should return something.

--- a/bulk_grades/__init__.py
+++ b/bulk_grades/__init__.py
@@ -4,6 +4,6 @@ Support for bulk scoring and grading.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = '0.6.4'
+__version__ = '0.6.5'
 
 default_app_config = 'bulk_grades.apps.BulkGradesConfig'  # pylint: disable=invalid-name

--- a/bulk_grades/api.py
+++ b/bulk_grades/api.py
@@ -26,6 +26,8 @@ __all__ = ('GradeCSVProcessor', 'ScoreCSVProcessor', 'get_score', 'get_scores', 
 
 log = logging.getLogger(__name__)
 
+UNKNOWN_LAST_SCORE_OVERRIDER = 'unknown'
+
 
 def _get_enrollments(course_id, track=None, cohort=None):
     """
@@ -613,7 +615,7 @@ def get_scores(usage_key, user_ids=None):
         try:
             last_override = row.scoreoverrider_set.select_related('user').latest('created')
         except ObjectDoesNotExist:
-            pass
+            scores[row.student_id]['who_last_graded'] = UNKNOWN_LAST_SCORE_OVERRIDER
         else:
             scores[row.student_id]['who_last_graded'] = last_override.user.username
     return scores


### PR DESCRIPTION
**Description:**
Accounts for the case where no `ScoreOverrider` records exists when fetching scores to add to a CSV.

**JIRA:**
https://openedx.atlassian.net/browse/EDUCATOR-4821

**Merge checklist:**
- [x] All reviewers approved
- [x] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)
