### PR TITLE
EDUCATOR-4928

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,8 @@ matrix:
 cache:
   - pip
 before_install:
-  - pip install --upgrade pip
+  # Pinned to version 19.3.1 due to error while running tests (tox) on Travis
+  - pip install --upgrade pip==19.3.1
 install:
   - pip install -r requirements/travis.txt
 script:

--- a/bulk_grades/__init__.py
+++ b/bulk_grades/__init__.py
@@ -4,6 +4,6 @@ Support for bulk scoring and grading.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = '0.6.6'
+__version__ = '0.6.7'
 
 default_app_config = 'bulk_grades.apps.BulkGradesConfig'  # pylint: disable=invalid-name

--- a/bulk_grades/api.py
+++ b/bulk_grades/api.py
@@ -270,7 +270,7 @@ class GradeCSVProcessor(DeferrableMixin, GradedSubsectionMixin, CSVProcessor):
         Create GradeCSVProcessor.
         """
         # First, set some default values.
-        self.columns = ['user_id', 'username', 'course_id', 'track', 'cohort']
+        self.columns = ['user_id', 'username', 'student_key', 'course_id', 'track', 'cohort']
         self.course_id = None
         self.subsection_grade_max = None
         self.subsection_grade_min = None
@@ -389,6 +389,7 @@ class GradeCSVProcessor(DeferrableMixin, GradedSubsectionMixin, CSVProcessor):
             row = {
                 'user_id': enrollment['user_id'],
                 'username': enrollment['username'],
+                'student_key': enrollment['student_uid'] if enrollment['track'] == 'masters' else None,
                 'track': enrollment['track'],
                 'course_id': self.course_id,
                 'cohort': cohort.name if cohort else None,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -272,6 +272,15 @@ class TestGradeProcessor(BaseTests):
     def test_export(self, course_grade_factory_mock):  # pylint: disable=unused-argument
         processor = api.GradeCSVProcessor(course_id=self.course_id)
         rows = list(processor.get_iterator())
+        # tests that there a 'student_key' column present
+        assert any('student_key' in row for row in rows)
+        # tests that a masters student has student_key populated
+        masters_row = [row for row in rows if 'masters' in row]
+        assert 'masters@example.com,ext:5,' in masters_row[0]
+        # tests that a non-masters (verified) student does NOT have a student key populated
+        verified_row = [row for row in rows if 'verified' in row]
+        # note the null between the two commas, in place where student_key is supposed to be
+        assert 'verified@example.com,,' in verified_row[0]
         assert len(rows) == self.NUM_USERS + 1
 
     @patch('lms.djangoapps.grades.api.graded_subsections_for_course_id')
@@ -291,6 +300,7 @@ class TestGradeProcessor(BaseTests):
         expected_columns = [
             'user_id',
             'username',
+            'student_key',
             'course_id',
             'track',
             'cohort',


### PR DESCRIPTION
Display student-key column for bulk export csv and populate it, it a student is in masters track.

[Jira](https://openedx.atlassian.net/browse/EDUCATOR-4928)

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)
