### PR TITLE
Updated Python and Django versions in Travis and Tox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,28 +1,15 @@
 language: python
 dist: xenial
 python:
-  - 2.7
   - 3.5
+  - 3.8
 env:
-  - TOXENV=django111
-  - TOXENV=django20
-  - TOXENV=django21
   - TOXENV=django22
-matrix:
-  exclude:
-    - python: 2.7
-      env: TOXENV=django20
-    - python: 2.7
-      env: TOXENV=django21
-    - python: 2.7
-      env: TOXENV=django22
-  include:
-    - python: 3.5
-      env: TOXENV=quality
-    - python: 3.5
-      env: TOXENV=docs
-    - python: 3.5
-      env: TOXENV=pii_check
+  - TOXENV=django30
+  - TOXENV=quality
+  - TOXENV=docs
+  - TOXENV=pii_check
+
 cache:
   - pip
 before_install:

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -1,9 +1,10 @@
 # Core requirements for using this application
 -c constraints.txt
 
-Django>=1.11              # Web application framework
+Django              # Web application framework
 django-model-utils        # Provides TimeStampedModel abstract base class
 edx-opaque-keys
 super-csv
 requests
 slumber
+six

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -8,11 +8,6 @@
 # pin when possible.  Writing an issue against the offending project and
 # linking to it here is good.
 
-# This packages is a backport which can only be installed on Python 2.7
-futures ; python_version == "2.7"
-
-# A dependency of pytest.  Pytest doesn't constrain it and 6.0.0 onward
-# only works with python 3
-more-itertools<6.0.0
-#Django 1.11 support was dropped in version 4.0.0
-django-model-utils<4.0.0 ; python_version == "2.7"
+# pip-tools==5.0.0 requires pip version 20.x but we are using pip=19.x right now.
+# can be removed once, we update pip to 20.x
+# pip-tools<5.0.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,13 @@
 [tox]
-envlist = {py27,py35}-django111,py35-django{20,21,22}
+envlist = py(35,38}-django{22,30}
 
 [testenv]
 setenv =
     PYTHONPATH = {toxinidir}/mock_apps/
 deps =
     -r{toxinidir}/requirements/test.txt
-    django111: Django>=1.11,<2.0
-    django20: Django>=2.0,<2.1
-    django21: Django>=2.1,<2.2
     django22: Django>=2.2,<2.3
+    django30: Django>=3.0,<3.1
 commands =
     python -Wd -m pytest {posargs}
 


### PR DESCRIPTION
**Description:** 
- Removed `Django<22` from Travis and tox.

**JIRA:** https://openedx.atlassian.net/browse/BOM-1559