### PR TITLE
Updated Python and Django versions in Travis and Tox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,28 +1,14 @@
 language: python
 dist: xenial
 python:
-  - 2.7
   - 3.5
+  - 3.8
 env:
-  - TOXENV=django111
-  - TOXENV=django20
-  - TOXENV=django21
   - TOXENV=django22
-matrix:
-  exclude:
-    - python: 2.7
-      env: TOXENV=django20
-    - python: 2.7
-      env: TOXENV=django21
-    - python: 2.7
-      env: TOXENV=django22
-  include:
-    - python: 3.5
-      env: TOXENV=quality
-    - python: 3.5
-      env: TOXENV=docs
-    - python: 3.5
-      env: TOXENV=pii_check
+  - TOXENV=quality
+  - TOXENV=docs
+  - TOXENV=pii_check
+
 cache:
   - pip
 before_install:
@@ -40,6 +26,7 @@ deploy:
   distributions: sdist bdist_wheel
   on:
     tags: true
+    python: 3.5
     condition: "$TOXENV = quality"
   password:
     secure: fqghurmaw5AV4v5e8udqjAhAppWax9cIof2nkKjVREIxURLuaAESFHg40fvA7q6eHsvZoXf34HIoFw2s7HBMe3dtYo4i+wY4JsMYyBPUGV3koSJe3ODwlx8A1IRv2i/WCDtfoFS8jZdeu02OQ6LHbf2P+Kmv3cX5qVCUez+E9bTBniPIqMd9MdA7bN5ft6BYcQttbxvK7sPRJ7Gkv+zKQdXjMpH/v9jjK5f4rAAtqHICymDrwurU7l01964TLTyyHKnB5kZNaTVc/nLMlU1gHSnO5wS7i3BJuzpI/2rjiIIaZJgQJA3U1wj5hHm0R9X7Bo4RSDv5i9Lrf6TPhArqORf6Nk5iLbMPRCCdUV99HkbV6rGJU8DjKFxdnbyBgQlAlQ0rSl0kx2pjtgcMk4JPez/E8JTpruj/J001MvmoK8KoceCIelDDNQRrUYwPldyUv8eB5GSttmtWWXiedHZwk/iyhLknEKCK8jt2s2H4OGlxaXppBSVMRJBJ8ylUpYfFcxwIiHp7A0tYgxUBSmWxGcx0iowrVwQ2AQxzAykd07au7Yt3ge2YI3tEtm6dvHXj/fYi3iuukCv+Nj853JbGN2sfBssmpfOmJEG0ezwQgVKcc19+6RB+CH1YfBnMqR1xPB5D8+EMUHPbPI0akgfXSM1133EJ1KUoG5pSDe8h804=

--- a/bulk_grades/__init__.py
+++ b/bulk_grades/__init__.py
@@ -4,6 +4,6 @@ Support for bulk scoring and grading.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = '0.6.8'
+__version__ = '0.6.9'
 
 default_app_config = 'bulk_grades.apps.BulkGradesConfig'  # pylint: disable=invalid-name

--- a/bulk_grades/api.py
+++ b/bulk_grades/api.py
@@ -116,7 +116,7 @@ class ScoreCSVProcessor(DeferrableMixin, CSVProcessor):
                 raise ValidationError(_('Points must be numbers.'))
             if points > self.max_points:
                 raise ValidationError(_('Points must not be greater than {}.').format(self.max_points))
-            elif points < 0:
+            if points < 0:
                 raise ValidationError(_('Points must be greater than 0'))
 
     # pylint: disable=inconsistent-return-statements
@@ -201,7 +201,7 @@ class ScoreCSVProcessor(DeferrableMixin, CSVProcessor):
             grades_api.task_compute_all_grades_for_course.apply_async(kwargs={'course_key': text_type(course_key)})
 
 
-class GradedSubsectionMixin(object):
+class GradedSubsectionMixin:
     """
     Mixin to help generated lists of graded subsections
     and appropriate column names for each.
@@ -413,7 +413,7 @@ class GradeCSVProcessor(DeferrableMixin, GradedSubsectionMixin, CSVProcessor):
                         (self.subsection_grade_max and (effective_grade > self.subsection_grade_max))
                 ):
                     continue
-
+            # pylint: disable=E1111
             course_grade = grades_api.CourseGradeFactory().read(enrollment['user'], course_key=self._course_key)
             course_grade_normalized = course_grade.percent * 100
 
@@ -512,7 +512,7 @@ class InterventionCSVProcessor(GradedSubsectionMixin, CSVProcessor):
                         (self.subsection_grade_max and (effective_grade > self.subsection_grade_max))
                 ):
                     continue
-
+            # pylint: disable=E1111
             course_grade = grades_api.CourseGradeFactory().read(enrollment['user'], course_key=self._course_key)
             if self.course_grade_min or self.course_grade_max:
                 course_grade_normalized = (course_grade.percent * 100)

--- a/bulk_grades/clients.py
+++ b/bulk_grades/clients.py
@@ -46,7 +46,7 @@ class TextSerializer(serialize.BaseSerializer):
     dumps = loads = unchanged
 
 
-# pylint: disable=missing-docstring
+# pylint: disable=missing-class-docstring
 class LearnerAPIClient(API):
 
     def __init__(self, timeout=5, serializer_type='json'):

--- a/bulk_grades/models.py
+++ b/bulk_grades/models.py
@@ -23,12 +23,11 @@ class ScoreOverrider(TimeStampedModel):
     created = models.DateTimeField(auto_now_add=True, db_index=True)
     user = models.ForeignKey(get_user_model(), on_delete=models.CASCADE)
 
-    class Meta(object):
+    class Meta:
         """Django model meta."""
 
         app_label = "bulk_grades"
 
     def __str__(self):
         """Return string representation."""
-        # pylint: disable=no-member
         return 'ScoreOverrider({}, {})'.format(self.module.module_state_key, self.user)

--- a/bulk_grades/views.py
+++ b/bulk_grades/views.py
@@ -37,7 +37,6 @@ class GradeOnlyExport(View):
         """
         Abstract method to initialize processor particular to the class.
         """
-        pass
 
     def dispatch(self, request, course_id, *args, **kwargs):  # pylint: disable=arguments-differ
         """

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -1,9 +1,11 @@
 # Core requirements for using this application
 -c constraints.txt
 
-Django>=1.11              # Web application framework
+Django              # Web application framework
+django-celery
 django-model-utils        # Provides TimeStampedModel abstract base class
 edx-opaque-keys
 super-csv
 requests
 slumber
+six

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,26 +8,27 @@ amqp==1.4.9               # via kombu
 anyjson==0.3.3            # via kombu
 billiard==3.3.0.23        # via celery
 celery==3.1.26.post2      # via django-celery, edx-celeryutils
-certifi==2019.11.28       # via requests
+certifi==2020.4.5.1       # via requests
 chardet==3.0.4            # via requests
-django-celery==3.3.1      # via edx-celeryutils, super-csv
-django-crum==0.7.5        # via super-csv
-django-model-utils==3.0.0 ; python_version == "2.7"
-django==1.11.26
-djangorestframework==3.9.4  # via super-csv
-edx-celeryutils==0.3.1    # via super-csv
-edx-opaque-keys==2.0.1
+django-celery==3.3.1      # via -r requirements/base.in
+django-crum==0.7.6        # via super-csv
+django-model-utils==4.0.0  # via -r requirements/base.in, edx-celeryutils, super-csv
+django==2.2.12            # via -c requirements/constraints.txt, -r requirements/base.in, django-celery, django-crum, django-model-utils, djangorestframework, edx-celeryutils, jsonfield2, super-csv
+djangorestframework==3.11.0  # via super-csv
+edx-celeryutils==0.5.0    # via super-csv
+edx-opaque-keys==2.1.0    # via -r requirements/base.in
 future==0.18.2            # via edx-celeryutils
-idna==2.8                 # via requests
-jsonfield==2.0.2          # via edx-celeryutils
+idna==2.9                 # via requests
+jsonfield2==3.0.3         # via -c requirements/constraints.txt, edx-celeryutils
 kombu==3.0.37             # via celery
-pbr==5.4.4                # via stevedore
-pymongo==3.10.0           # via edx-opaque-keys
-pytz==2019.3              # via celery, django
-requests==2.22.0
+pbr==5.4.5                # via stevedore
+pymongo==3.10.1           # via edx-opaque-keys
+pytz==2020.1              # via celery, django
+requests==2.23.0          # via -r requirements/base.in, slumber
 simplejson==3.17.0        # via super-csv
-six==1.13.0               # via edx-opaque-keys, stevedore
-slumber==0.7.1
-stevedore==1.31.0         # via edx-opaque-keys
-super-csv==0.9.6
-urllib3==1.25.7           # via requests
+six==1.14.0               # via -r requirements/base.in, edx-opaque-keys, stevedore
+slumber==0.7.1            # via -r requirements/base.in
+sqlparse==0.3.1           # via django
+stevedore==1.32.0         # via edx-opaque-keys
+super-csv==0.9.7          # via -r requirements/base.in
+urllib3==1.25.9           # via requests

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -8,11 +8,18 @@
 # pin when possible.  Writing an issue against the offending project and
 # linking to it here is good.
 
-# This packages is a backport which can only be installed on Python 2.7
-futures ; python_version == "2.7"
+# Stay on an LTS release
+django<2.3
 
-# A dependency of pytest.  Pytest doesn't constrain it and 6.0.0 onward
-# only works with python 3
-more-itertools<6.0.0
-#Django 1.11 support was dropped in version 4.0.0
-django-model-utils<4.0.0 ; python_version == "2.7"
+# zipp>=2.0.0 dropped support for python3.5
+zipp<2.0.0
+
+# jsonfield2>3.0.3 removed support for python3.5
+jsonfield2<=3.0.3
+
+
+# mock version 4.0.0 drops support for python 3.5
+mock<4.0.0
+
+# greater versions drops support for python 3.5
+twine<2.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,97 +4,92 @@
 #
 #    make upgrade
 #
-amqp==1.4.9
-anyjson==0.3.3
-argparse==1.4.0
-astroid==1.6.6
-atomicwrites==1.3.0
-attrs==19.3.0
-backports.functools-lru-cache==1.6.1
-backports.os==0.1.1       # via path.py
-billiard==3.3.0.23
-caniusepython3==7.2.0
-celery==3.1.26.post2
-certifi==2019.11.28
-chardet==3.0.4
-click-log==0.3.2
-click==7.0
-code-annotations==0.3.2
-codecov==2.0.15
-configparser==4.0.2
-contextlib2==0.6.0.post1
-coverage==4.5.4
-ddt==1.2.2
-diff-cover==2.4.1
-distlib==0.3.0
-django-celery==3.3.1
-django-crum==0.7.5
-django-model-utils==3.0.0 ; python_version == "2.7"
-django==1.11.26
-djangorestframework==3.9.4
-edx-celeryutils==0.3.1
-edx-i18n-tools==0.4.8
-edx-lint==1.4.1
-edx-opaque-keys==2.0.1
-enum34==1.1.6
-filelock==3.0.12
-funcsigs==1.0.2
-future==0.18.2
-futures==3.3.0 ; python_version == "2.7"
-idna==2.8
-importlib-metadata==1.3.0
-inflect==3.0.2            # via jinja2-pluralize
-isort==4.3.21
+amqp==1.4.9               # via -r requirements/quality.txt, kombu
+anyjson==0.3.3            # via -r requirements/quality.txt, kombu
+appdirs==1.4.3            # via -r requirements/travis.txt, virtualenv
+argparse==1.4.0           # via -r requirements/quality.txt, caniusepython3
+astroid==2.3.3            # via -r requirements/quality.txt, pylint, pylint-celery
+attrs==19.3.0             # via -r requirements/quality.txt, pytest
+backports.functools-lru-cache==1.6.1  # via -r requirements/quality.txt, caniusepython3
+billiard==3.3.0.23        # via -r requirements/quality.txt, celery
+caniusepython3==7.2.0     # via -r requirements/quality.txt
+celery==3.1.26.post2      # via -r requirements/quality.txt, django-celery, edx-celeryutils
+certifi==2020.4.5.1       # via -r requirements/quality.txt, -r requirements/travis.txt, requests
+chardet==3.0.4            # via -r requirements/quality.txt, -r requirements/travis.txt, requests
+click-log==0.3.2          # via -r requirements/quality.txt, edx-lint
+click==7.1.2              # via -r requirements/pip-tools.txt, -r requirements/quality.txt, click-log, code-annotations, edx-lint, pip-tools
+code-annotations==0.3.3   # via -r requirements/quality.txt
+codecov==2.0.22           # via -r requirements/travis.txt
+coverage==5.1             # via -r requirements/quality.txt, -r requirements/travis.txt, codecov, pytest-cov
+ddt==1.3.1                # via -r requirements/quality.txt
+diff-cover==2.6.1         # via -r requirements/dev.in
+distlib==0.3.0            # via -r requirements/quality.txt, -r requirements/travis.txt, caniusepython3, virtualenv
+django-celery==3.3.1      # via -r requirements/quality.txt
+django-crum==0.7.6        # via -r requirements/quality.txt, super-csv
+django-model-utils==4.0.0  # via -r requirements/quality.txt, edx-celeryutils, super-csv
+django==2.2.12            # via -c requirements/constraints.txt, -r requirements/quality.txt, code-annotations, django-celery, django-crum, django-model-utils, djangorestframework, edx-celeryutils, edx-i18n-tools, jsonfield2, super-csv
+djangorestframework==3.11.0  # via -r requirements/quality.txt, super-csv
+edx-celeryutils==0.5.0    # via -r requirements/quality.txt, super-csv
+edx-i18n-tools==0.5.0     # via -r requirements/dev.in
+edx-lint==1.4.1           # via -r requirements/quality.txt
+edx-opaque-keys==2.1.0    # via -r requirements/quality.txt
+filelock==3.0.12          # via -r requirements/travis.txt, tox, virtualenv
+future==0.18.2            # via -r requirements/quality.txt, edx-celeryutils
+idna==2.9                 # via -r requirements/quality.txt, -r requirements/travis.txt, requests
+importlib-metadata==1.6.0  # via -r requirements/quality.txt, -r requirements/travis.txt, inflect, path, pluggy, pytest, tox, virtualenv
+inflect==4.1.0            # via jinja2-pluralize
+isort==4.3.21             # via -r requirements/quality.txt, pylint
 jinja2-pluralize==0.3.0   # via diff-cover
-jinja2==2.10.3
-jsonfield==2.0.2
-kombu==3.0.37
-lazy-object-proxy==1.4.3
-markupsafe==1.1.1
-mccabe==0.6.1
-mock==3.0.5
-more-itertools==5.0.0
-packaging==19.2
-path.py==11.5.2           # via edx-i18n-tools
-pathlib2==2.3.5
-pbr==5.4.4
-pip-tools==4.3.0
-pluggy==0.13.1
+jinja2==2.11.2            # via -r requirements/quality.txt, code-annotations, diff-cover, jinja2-pluralize
+jsonfield2==3.0.3         # via -c requirements/constraints.txt, -r requirements/quality.txt, edx-celeryutils
+kombu==3.0.37             # via -r requirements/quality.txt, celery
+lazy-object-proxy==1.4.3  # via -r requirements/quality.txt, astroid
+markupsafe==1.1.1         # via -r requirements/quality.txt, jinja2
+mccabe==0.6.1             # via -r requirements/quality.txt, pylint
+mock==3.0.5               # via -c requirements/constraints.txt, -r requirements/quality.txt
+more-itertools==8.2.0     # via -r requirements/quality.txt, pytest
+packaging==20.3           # via -r requirements/quality.txt, -r requirements/travis.txt, caniusepython3, pytest, tox
+path.py==12.4.0           # via edx-i18n-tools
+path==13.1.0              # via path.py
+pbr==5.4.5                # via -r requirements/quality.txt, stevedore
+pip-tools==5.1.1          # via -r requirements/pip-tools.txt
+pluggy==0.13.1            # via -r requirements/quality.txt, -r requirements/travis.txt, diff-cover, pytest, tox
 polib==1.1.0              # via edx-i18n-tools
-py==1.8.0
-pycodestyle==2.5.0
-pydocstyle==3.0.0
-pygments==2.5.2           # via diff-cover
-pylint-celery==0.3
-pylint-django==0.11.1
-pylint-plugin-utils==0.6
-pylint==1.9.5
-pymongo==3.10.0
-pyparsing==2.4.5
-pytest-cov==2.8.1
-pytest-django==3.7.0
-pytest==4.6.7
-python-slugify==4.0.0
-pytz==2019.3
-pyyaml==5.2
-requests==2.22.0
-scandir==1.10.0
-simplejson==3.17.0
-singledispatch==3.4.0.3
-six==1.13.0
-slumber==0.7.1
-snowballstemmer==2.0.0
-stevedore==1.31.0
-super-csv==0.9.6
-text-unidecode==1.3
-toml==0.10.0
-tox-battery==0.5.1
-tox==3.14.2
-urllib3==1.25.7
-virtualenv==16.7.8
-wcwidth==0.1.7
-wrapt==1.11.2
-zipp==0.6.0
+py==1.8.1                 # via -r requirements/quality.txt, -r requirements/travis.txt, pytest, tox
+pycodestyle==2.5.0        # via -r requirements/quality.txt
+pydocstyle==5.0.2         # via -r requirements/quality.txt
+pygments==2.6.1           # via diff-cover
+pylint-celery==0.3        # via -r requirements/quality.txt, edx-lint
+pylint-django==2.0.11     # via -r requirements/quality.txt, edx-lint
+pylint-plugin-utils==0.6  # via -r requirements/quality.txt, pylint-celery, pylint-django
+pylint==2.4.2             # via -r requirements/quality.txt, edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
+pymongo==3.10.1           # via -r requirements/quality.txt, edx-opaque-keys
+pyparsing==2.4.7          # via -r requirements/quality.txt, -r requirements/travis.txt, packaging
+pytest-cov==2.8.1         # via -r requirements/quality.txt
+pytest-django==3.9.0      # via -r requirements/quality.txt
+pytest==5.4.1             # via -r requirements/quality.txt, pytest-cov, pytest-django
+python-slugify==4.0.0     # via -r requirements/quality.txt, code-annotations
+pytz==2020.1              # via -r requirements/quality.txt, celery, django
+pyyaml==5.3.1             # via -r requirements/quality.txt, code-annotations, edx-i18n-tools
+requests==2.23.0          # via -r requirements/quality.txt, -r requirements/travis.txt, caniusepython3, codecov, slumber
+simplejson==3.17.0        # via -r requirements/quality.txt, super-csv
+six==1.14.0               # via -r requirements/pip-tools.txt, -r requirements/quality.txt, -r requirements/travis.txt, astroid, diff-cover, edx-i18n-tools, edx-lint, edx-opaque-keys, mock, packaging, pip-tools, stevedore, tox, virtualenv
+slumber==0.7.1            # via -r requirements/quality.txt
+snowballstemmer==2.0.0    # via -r requirements/quality.txt, pydocstyle
+sqlparse==0.3.1           # via -r requirements/quality.txt, django
+stevedore==1.32.0         # via -r requirements/quality.txt, code-annotations, edx-opaque-keys
+super-csv==0.9.7          # via -r requirements/quality.txt
+text-unidecode==1.3       # via -r requirements/quality.txt, python-slugify
+toml==0.10.0              # via -r requirements/travis.txt, tox
+tox-battery==0.5.2        # via -r requirements/travis.txt
+tox==3.14.6               # via -r requirements/travis.txt, tox-battery
+typed-ast==1.4.1          # via -r requirements/quality.txt, astroid
+urllib3==1.25.9           # via -r requirements/quality.txt, -r requirements/travis.txt, requests
+virtualenv==20.0.18       # via -r requirements/travis.txt, tox
+wcwidth==0.1.9            # via -r requirements/quality.txt, pytest
+wrapt==1.11.2             # via -r requirements/quality.txt, astroid
+zipp==1.2.0               # via -c requirements/constraints.txt, -r requirements/quality.txt, -r requirements/travis.txt, importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
+# pip
 # setuptools

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -5,79 +5,78 @@
 #    make upgrade
 #
 alabaster==0.7.12         # via sphinx
-amqp==1.4.9
-anyjson==0.3.3
-atomicwrites==1.3.0
-attrs==19.3.0
-babel==2.7.0              # via sphinx
-billiard==3.3.0.23
-bleach==3.1.0             # via readme-renderer
-celery==3.1.26.post2
-certifi==2019.11.28
-chardet==3.0.4
-click==7.0
-code-annotations==0.3.2
-configparser==4.0.2
-contextlib2==0.6.0.post1
-coverage==4.5.4
-ddt==1.2.2
-django-celery==3.3.1
-django-crum==0.7.5
-django-model-utils==3.0.0 ; python_version == "2.7"
-django==1.11.26
-djangorestframework==3.9.4
-doc8==0.8.0
-docutils==0.15.2          # via doc8, readme-renderer, restructuredtext-lint, sphinx
-edx-celeryutils==0.3.1
-edx-opaque-keys==2.0.1
-edx-sphinx-theme==1.5.0
-funcsigs==1.0.2
-future==0.18.2
-idna==2.8
-imagesize==1.1.0          # via sphinx
-importlib-metadata==1.3.0
-jinja2==2.10.3
-jsonfield==2.0.2
-kombu==3.0.37
-markupsafe==1.1.1
-mock==3.0.5
-more-itertools==5.0.0
-packaging==19.2
-pathlib2==2.3.5
-pbr==5.4.4
+amqp==1.4.9               # via -r requirements/test.txt, kombu
+anyjson==0.3.3            # via -r requirements/test.txt, kombu
+attrs==19.3.0             # via -r requirements/test.txt, pytest
+babel==2.8.0              # via sphinx
+billiard==3.3.0.23        # via -r requirements/test.txt, celery
+bleach==3.1.5             # via readme-renderer
+celery==3.1.26.post2      # via -r requirements/test.txt, django-celery, edx-celeryutils
+certifi==2020.4.5.1       # via -r requirements/test.txt, requests
+chardet==3.0.4            # via -r requirements/test.txt, doc8, requests
+click==7.1.2              # via -r requirements/test.txt, code-annotations
+code-annotations==0.3.3   # via -r requirements/test.txt
+coverage==5.1             # via -r requirements/test.txt, pytest-cov
+ddt==1.3.1                # via -r requirements/test.txt
+django-celery==3.3.1      # via -r requirements/test.txt
+django-crum==0.7.6        # via -r requirements/test.txt, super-csv
+django-model-utils==4.0.0  # via -r requirements/test.txt, edx-celeryutils, super-csv
+django==2.2.12            # via -c requirements/constraints.txt, -r requirements/test.txt, code-annotations, django-celery, django-crum, django-model-utils, djangorestframework, edx-celeryutils, jsonfield2, super-csv
+djangorestframework==3.11.0  # via -r requirements/test.txt, super-csv
+doc8==0.8.0               # via -r requirements/doc.in
+docutils==0.16            # via doc8, readme-renderer, restructuredtext-lint, sphinx
+edx-celeryutils==0.5.0    # via -r requirements/test.txt, super-csv
+edx-opaque-keys==2.1.0    # via -r requirements/test.txt
+edx-sphinx-theme==1.5.0   # via -r requirements/doc.in
+future==0.18.2            # via -r requirements/test.txt, edx-celeryutils
+idna==2.9                 # via -r requirements/test.txt, requests
+imagesize==1.2.0          # via sphinx
+importlib-metadata==1.6.0  # via -r requirements/test.txt, pluggy, pytest
+jinja2==2.11.2            # via -r requirements/test.txt, code-annotations, sphinx
+jsonfield2==3.0.3         # via -c requirements/constraints.txt, -r requirements/test.txt, edx-celeryutils
+kombu==3.0.37             # via -r requirements/test.txt, celery
+markupsafe==1.1.1         # via -r requirements/test.txt, jinja2
+mock==3.0.5               # via -c requirements/constraints.txt, -r requirements/test.txt
+more-itertools==8.2.0     # via -r requirements/test.txt, pytest
+packaging==20.3           # via -r requirements/test.txt, bleach, pytest, sphinx
+pbr==5.4.5                # via -r requirements/test.txt, stevedore
 pkginfo==1.5.0.1          # via twine
-pluggy==0.13.1
-py==1.8.0
-pygments==2.5.2           # via readme-renderer, sphinx
-pymongo==3.10.0
-pyparsing==2.4.5
-pytest-cov==2.8.1
-pytest-django==3.7.0
-pytest==4.6.7
-python-slugify==4.0.0
-pytz==2019.3
-pyyaml==5.2
-readme-renderer==24.0
+pluggy==0.13.1            # via -r requirements/test.txt, pytest
+py==1.8.1                 # via -r requirements/test.txt, pytest
+pygments==2.6.1           # via readme-renderer, sphinx
+pymongo==3.10.1           # via -r requirements/test.txt, edx-opaque-keys
+pyparsing==2.4.7          # via -r requirements/test.txt, packaging
+pytest-cov==2.8.1         # via -r requirements/test.txt
+pytest-django==3.9.0      # via -r requirements/test.txt
+pytest==5.4.1             # via -r requirements/test.txt, pytest-cov, pytest-django
+python-slugify==4.0.0     # via -r requirements/test.txt, code-annotations
+pytz==2020.1              # via -r requirements/test.txt, babel, celery, django
+pyyaml==5.3.1             # via -r requirements/test.txt, code-annotations
+readme-renderer==26.0     # via -r requirements/doc.in, twine
 requests-toolbelt==0.9.1  # via twine
-requests==2.22.0
+requests==2.23.0          # via -r requirements/test.txt, requests-toolbelt, slumber, sphinx, twine
 restructuredtext-lint==1.3.0  # via doc8
-scandir==1.10.0
-simplejson==3.17.0
-six==1.13.0
-slumber==0.7.1
+simplejson==3.17.0        # via -r requirements/test.txt, super-csv
+six==1.14.0               # via -r requirements/test.txt, bleach, doc8, edx-opaque-keys, edx-sphinx-theme, mock, packaging, readme-renderer, stevedore
+slumber==0.7.1            # via -r requirements/test.txt
 snowballstemmer==2.0.0    # via sphinx
-sphinx==1.8.5
-sphinxcontrib-websupport==1.1.2  # via sphinx
-stevedore==1.31.0
-super-csv==0.9.6
-text-unidecode==1.3
-tqdm==4.40.2              # via twine
-twine==1.15.0
-typing==3.7.4.1           # via sphinx
-urllib3==1.25.7
-wcwidth==0.1.7
+sphinx==3.0.3             # via -r requirements/doc.in, edx-sphinx-theme
+sphinxcontrib-applehelp==1.0.2  # via sphinx
+sphinxcontrib-devhelp==1.0.2  # via sphinx
+sphinxcontrib-htmlhelp==1.0.3  # via sphinx
+sphinxcontrib-jsmath==1.0.1  # via sphinx
+sphinxcontrib-qthelp==1.0.3  # via sphinx
+sphinxcontrib-serializinghtml==1.1.4  # via sphinx
+sqlparse==0.3.1           # via -r requirements/test.txt, django
+stevedore==1.32.0         # via -r requirements/test.txt, code-annotations, doc8, edx-opaque-keys
+super-csv==0.9.7          # via -r requirements/test.txt
+text-unidecode==1.3       # via -r requirements/test.txt, python-slugify
+tqdm==4.45.0              # via twine
+twine==1.15.0             # via -c requirements/constraints.txt, -r requirements/doc.in
+urllib3==1.25.9           # via -r requirements/test.txt, requests
+wcwidth==0.1.9            # via -r requirements/test.txt, pytest
 webencodings==0.5.1       # via bleach
-zipp==0.6.0
+zipp==1.2.0               # via -c requirements/constraints.txt, -r requirements/test.txt, importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -4,6 +4,9 @@
 #
 #    make upgrade
 #
-click==7.0                # via pip-tools
-pip-tools==4.3.0
-six==1.13.0               # via pip-tools
+click==7.1.2              # via pip-tools
+pip-tools==5.1.1          # via -r requirements/pip-tools.in
+six==1.14.0               # via pip-tools
+
+# The following packages are considered to be unsafe in a requirements file:
+# pip

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -4,82 +4,75 @@
 #
 #    make upgrade
 #
-amqp==1.4.9
-anyjson==0.3.3
+amqp==1.4.9               # via -r requirements/test.txt, kombu
+anyjson==0.3.3            # via -r requirements/test.txt, kombu
 argparse==1.4.0           # via caniusepython3
-astroid==1.6.6            # via pylint, pylint-celery
-atomicwrites==1.3.0
-attrs==19.3.0
-backports.functools-lru-cache==1.6.1  # via astroid, caniusepython3, isort, pylint
-billiard==3.3.0.23
-caniusepython3==7.2.0
-celery==3.1.26.post2
-certifi==2019.11.28
-chardet==3.0.4
+astroid==2.3.3            # via pylint, pylint-celery
+attrs==19.3.0             # via -r requirements/test.txt, pytest
+backports.functools-lru-cache==1.6.1  # via caniusepython3
+billiard==3.3.0.23        # via -r requirements/test.txt, celery
+caniusepython3==7.2.0     # via -r requirements/quality.in
+celery==3.1.26.post2      # via -r requirements/test.txt, django-celery, edx-celeryutils
+certifi==2020.4.5.1       # via -r requirements/test.txt, requests
+chardet==3.0.4            # via -r requirements/test.txt, requests
 click-log==0.3.2          # via edx-lint
-click==7.0
-code-annotations==0.3.2
-configparser==4.0.2
-contextlib2==0.6.0.post1
-coverage==4.5.4
-ddt==1.2.2
+click==7.1.2              # via -r requirements/test.txt, click-log, code-annotations, edx-lint
+code-annotations==0.3.3   # via -r requirements/test.txt
+coverage==5.1             # via -r requirements/test.txt, pytest-cov
+ddt==1.3.1                # via -r requirements/test.txt
 distlib==0.3.0            # via caniusepython3
-django-celery==3.3.1
-django-crum==0.7.5
-django-model-utils==3.0.0 ; python_version == "2.7"
-django==1.11.26
-djangorestframework==3.9.4
-edx-celeryutils==0.3.1
-edx-lint==1.4.1
-edx-opaque-keys==2.0.1
-enum34==1.1.6             # via astroid
-funcsigs==1.0.2
-future==0.18.2
-futures==3.3.0 ; python_version == "2.7"  # via caniusepython3, isort
-idna==2.8
-importlib-metadata==1.3.0
-isort==4.3.21
-jinja2==2.10.3
-jsonfield==2.0.2
-kombu==3.0.37
+django-celery==3.3.1      # via -r requirements/test.txt
+django-crum==0.7.6        # via -r requirements/test.txt, super-csv
+django-model-utils==4.0.0  # via -r requirements/test.txt, edx-celeryutils, super-csv
+django==2.2.12            # via -c requirements/constraints.txt, -r requirements/test.txt, code-annotations, django-celery, django-crum, django-model-utils, djangorestframework, edx-celeryutils, jsonfield2, super-csv
+djangorestframework==3.11.0  # via -r requirements/test.txt, super-csv
+edx-celeryutils==0.5.0    # via -r requirements/test.txt, super-csv
+edx-lint==1.4.1           # via -r requirements/quality.in
+edx-opaque-keys==2.1.0    # via -r requirements/test.txt
+future==0.18.2            # via -r requirements/test.txt, edx-celeryutils
+idna==2.9                 # via -r requirements/test.txt, requests
+importlib-metadata==1.6.0  # via -r requirements/test.txt, pluggy, pytest
+isort==4.3.21             # via -r requirements/quality.in, pylint
+jinja2==2.11.2            # via -r requirements/test.txt, code-annotations
+jsonfield2==3.0.3         # via -c requirements/constraints.txt, -r requirements/test.txt, edx-celeryutils
+kombu==3.0.37             # via -r requirements/test.txt, celery
 lazy-object-proxy==1.4.3  # via astroid
-markupsafe==1.1.1
+markupsafe==1.1.1         # via -r requirements/test.txt, jinja2
 mccabe==0.6.1             # via pylint
-mock==3.0.5
-more-itertools==5.0.0
-packaging==19.2
-pathlib2==2.3.5
-pbr==5.4.4
-pluggy==0.13.1
-py==1.8.0
-pycodestyle==2.5.0
-pydocstyle==3.0.0
+mock==3.0.5               # via -c requirements/constraints.txt, -r requirements/test.txt
+more-itertools==8.2.0     # via -r requirements/test.txt, pytest
+packaging==20.3           # via -r requirements/test.txt, caniusepython3, pytest
+pbr==5.4.5                # via -r requirements/test.txt, stevedore
+pluggy==0.13.1            # via -r requirements/test.txt, pytest
+py==1.8.1                 # via -r requirements/test.txt, pytest
+pycodestyle==2.5.0        # via -r requirements/quality.in
+pydocstyle==5.0.2         # via -r requirements/quality.in
 pylint-celery==0.3        # via edx-lint
-pylint-django==0.11.1     # via edx-lint
+pylint-django==2.0.11     # via edx-lint
 pylint-plugin-utils==0.6  # via pylint-celery, pylint-django
-pylint==1.9.5             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
-pymongo==3.10.0
-pyparsing==2.4.5
-pytest-cov==2.8.1
-pytest-django==3.7.0
-pytest==4.6.7
-python-slugify==4.0.0
-pytz==2019.3
-pyyaml==5.2
-requests==2.22.0
-scandir==1.10.0
-simplejson==3.17.0
-singledispatch==3.4.0.3   # via astroid, pylint
-six==1.13.0
-slumber==0.7.1
+pylint==2.4.2             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
+pymongo==3.10.1           # via -r requirements/test.txt, edx-opaque-keys
+pyparsing==2.4.7          # via -r requirements/test.txt, packaging
+pytest-cov==2.8.1         # via -r requirements/test.txt
+pytest-django==3.9.0      # via -r requirements/test.txt
+pytest==5.4.1             # via -r requirements/test.txt, pytest-cov, pytest-django
+python-slugify==4.0.0     # via -r requirements/test.txt, code-annotations
+pytz==2020.1              # via -r requirements/test.txt, celery, django
+pyyaml==5.3.1             # via -r requirements/test.txt, code-annotations
+requests==2.23.0          # via -r requirements/test.txt, caniusepython3, slumber
+simplejson==3.17.0        # via -r requirements/test.txt, super-csv
+six==1.14.0               # via -r requirements/test.txt, astroid, edx-lint, edx-opaque-keys, mock, packaging, stevedore
+slumber==0.7.1            # via -r requirements/test.txt
 snowballstemmer==2.0.0    # via pydocstyle
-stevedore==1.31.0
-super-csv==0.9.6
-text-unidecode==1.3
-urllib3==1.25.7
-wcwidth==0.1.7
+sqlparse==0.3.1           # via -r requirements/test.txt, django
+stevedore==1.32.0         # via -r requirements/test.txt, code-annotations, edx-opaque-keys
+super-csv==0.9.7          # via -r requirements/test.txt
+text-unidecode==1.3       # via -r requirements/test.txt, python-slugify
+typed-ast==1.4.1          # via astroid
+urllib3==1.25.9           # via -r requirements/test.txt, requests
+wcwidth==0.1.9            # via -r requirements/test.txt, pytest
 wrapt==1.11.2             # via astroid
-zipp==0.6.0
+zipp==1.2.0               # via -c requirements/constraints.txt, -r requirements/test.txt, importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,57 +4,52 @@
 #
 #    make upgrade
 #
-amqp==1.4.9
-anyjson==0.3.3
-atomicwrites==1.3.0       # via pytest
+amqp==1.4.9               # via -r requirements/base.txt, kombu
+anyjson==0.3.3            # via -r requirements/base.txt, kombu
 attrs==19.3.0             # via pytest
-billiard==3.3.0.23
-celery==3.1.26.post2
-certifi==2019.11.28
-chardet==3.0.4
-click==7.0                # via code-annotations
-code-annotations==0.3.2
-configparser==4.0.2       # via importlib-metadata
-contextlib2==0.6.0.post1  # via importlib-metadata
-coverage==4.5.4           # via pytest-cov
-ddt==1.2.2
-django-celery==3.3.1
-django-crum==0.7.5
-django-model-utils==3.0.0 ; python_version == "2.7"
-djangorestframework==3.9.4
-edx-celeryutils==0.3.1
-edx-opaque-keys==2.0.1
-funcsigs==1.0.2           # via mock, pytest
-future==0.18.2
-idna==2.8
-importlib-metadata==1.3.0  # via pluggy, pytest
-jinja2==2.10.3            # via code-annotations
-jsonfield==2.0.2
-kombu==3.0.37
+billiard==3.3.0.23        # via -r requirements/base.txt, celery
+celery==3.1.26.post2      # via -r requirements/base.txt, django-celery, edx-celeryutils
+certifi==2020.4.5.1       # via -r requirements/base.txt, requests
+chardet==3.0.4            # via -r requirements/base.txt, requests
+click==7.1.2              # via code-annotations
+code-annotations==0.3.3   # via -r requirements/test.in
+coverage==5.1             # via pytest-cov
+ddt==1.3.1                # via -r requirements/test.in
+django-celery==3.3.1      # via -r requirements/base.txt
+django-crum==0.7.6        # via -r requirements/base.txt, super-csv
+django-model-utils==4.0.0  # via -r requirements/base.txt, edx-celeryutils, super-csv
+djangorestframework==3.11.0  # via -r requirements/base.txt, super-csv
+edx-celeryutils==0.5.0    # via -r requirements/base.txt, super-csv
+edx-opaque-keys==2.1.0    # via -r requirements/base.txt
+future==0.18.2            # via -r requirements/base.txt, edx-celeryutils
+idna==2.9                 # via -r requirements/base.txt, requests
+importlib-metadata==1.6.0  # via pluggy, pytest
+jinja2==2.11.2            # via code-annotations
+jsonfield2==3.0.3         # via -c requirements/constraints.txt, -r requirements/base.txt, edx-celeryutils
+kombu==3.0.37             # via -r requirements/base.txt, celery
 markupsafe==1.1.1         # via jinja2
-mock==3.0.5
-more-itertools==5.0.0     # via pytest, zipp
-packaging==19.2           # via pytest
-pathlib2==2.3.5           # via importlib-metadata, pytest, pytest-django
-pbr==5.4.4
+mock==3.0.5               # via -c requirements/constraints.txt, -r requirements/test.in
+more-itertools==8.2.0     # via pytest
+packaging==20.3           # via pytest
+pbr==5.4.5                # via -r requirements/base.txt, stevedore
 pluggy==0.13.1            # via pytest
-py==1.8.0                 # via pytest
-pymongo==3.10.0
-pyparsing==2.4.5          # via packaging
-pytest-cov==2.8.1
-pytest-django==3.7.0
-pytest==4.6.7             # via pytest-cov, pytest-django
+py==1.8.1                 # via pytest
+pymongo==3.10.1           # via -r requirements/base.txt, edx-opaque-keys
+pyparsing==2.4.7          # via packaging
+pytest-cov==2.8.1         # via -r requirements/test.in
+pytest-django==3.9.0      # via -r requirements/test.in
+pytest==5.4.1             # via pytest-cov, pytest-django
 python-slugify==4.0.0     # via code-annotations
-pytz==2019.3
-pyyaml==5.2               # via code-annotations
-requests==2.22.0
-scandir==1.10.0           # via pathlib2
-simplejson==3.17.0
-six==1.13.0
-slumber==0.7.1
-stevedore==1.31.0
-super-csv==0.9.6
+pytz==2020.1              # via -r requirements/base.txt, celery, django
+pyyaml==5.3.1             # via code-annotations
+requests==2.23.0          # via -r requirements/base.txt, slumber
+simplejson==3.17.0        # via -r requirements/base.txt, super-csv
+six==1.14.0               # via -r requirements/base.txt, edx-opaque-keys, mock, packaging, stevedore
+slumber==0.7.1            # via -r requirements/base.txt
+sqlparse==0.3.1           # via -r requirements/base.txt, django
+stevedore==1.32.0         # via -r requirements/base.txt, code-annotations, edx-opaque-keys
+super-csv==0.9.7          # via -r requirements/base.txt
 text-unidecode==1.3       # via python-slugify
-urllib3==1.25.7
-wcwidth==0.1.7            # via pytest
-zipp==0.6.0               # via importlib-metadata
+urllib3==1.25.9           # via -r requirements/base.txt, requests
+wcwidth==0.1.9            # via pytest
+zipp==1.2.0               # via -c requirements/constraints.txt, importlib-metadata

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -4,27 +4,24 @@
 #
 #    make upgrade
 #
-certifi==2019.11.28       # via requests
+appdirs==1.4.3            # via virtualenv
+certifi==2020.4.5.1       # via requests
 chardet==3.0.4            # via requests
-codecov==2.0.15
-configparser==4.0.2       # via importlib-metadata
-contextlib2==0.6.0.post1  # via importlib-metadata
-coverage==4.5.4           # via codecov
-filelock==3.0.12          # via tox
-idna==2.8                 # via requests
-importlib-metadata==1.3.0  # via pluggy, tox
-more-itertools==5.0.0     # via zipp
-packaging==19.2           # via tox
-pathlib2==2.3.5           # via importlib-metadata
+codecov==2.0.22           # via -r requirements/travis.in
+coverage==5.1             # via codecov
+distlib==0.3.0            # via virtualenv
+filelock==3.0.12          # via tox, virtualenv
+idna==2.9                 # via requests
+importlib-metadata==1.6.0  # via pluggy, tox, virtualenv
+packaging==20.3           # via tox
 pluggy==0.13.1            # via tox
-py==1.8.0                 # via tox
-pyparsing==2.4.5          # via packaging
-requests==2.22.0          # via codecov
-scandir==1.10.0           # via pathlib2
-six==1.13.0               # via more-itertools, packaging, pathlib2, tox
+py==1.8.1                 # via tox
+pyparsing==2.4.7          # via packaging
+requests==2.23.0          # via codecov
+six==1.14.0               # via packaging, tox, virtualenv
 toml==0.10.0              # via tox
-tox-battery==0.5.1
-tox==3.14.2
-urllib3==1.25.7           # via requests
-virtualenv==16.7.8        # via tox
-zipp==0.6.0               # via importlib-metadata
+tox-battery==0.5.2        # via -r requirements/travis.in
+tox==3.14.6               # via -r requirements/travis.in, tox-battery
+urllib3==1.25.9           # via requests
+virtualenv==20.0.18       # via tox
+zipp==1.2.0               # via -c requirements/constraints.txt, importlib-metadata

--- a/setup.py
+++ b/setup.py
@@ -82,17 +82,13 @@ setup(
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Framework :: Django',
-        'Framework :: Django :: 1.11',
-        'Framework :: Django :: 2.0',
-        'Framework :: Django :: 2.1',
         'Framework :: Django :: 2.2',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: GNU Affero General Public License v3 or later (AGPLv3+)',
         'Natural Language :: English',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.8',
     ],
     entry_points={
         'lms.djangoapp': [

--- a/tox.ini
+++ b/tox.ini
@@ -1,14 +1,11 @@
 [tox]
-envlist = {py27,py35}-django111,py35-django{20,21,22}
+envlist = py(35,38}-django{22}
 
 [testenv]
 setenv =
     PYTHONPATH = {toxinidir}/mock_apps/
 deps =
     -r{toxinidir}/requirements/test.txt
-    django111: Django>=1.11,<2.0
-    django20: Django>=2.0,<2.1
-    django21: Django>=2.1,<2.2
     django22: Django>=2.2,<2.3
 commands =
     python -Wd -m pytest {posargs}


### PR DESCRIPTION
**Issue:** [BOM-1559](https://openedx.atlassian.net/browse/BOM-1559)

### Changes in Tox and Travis
- Removed `python2.7` and added `python3.8`.
- Removed `django111`, `django20`, and `django21`.
- Updated constraints and made quality fixes.