### PR TITLE
Removing django-celery other celery upgrade will not work.

### DIFF
--- a/.annotation_safe_list.yml
+++ b/.annotation_safe_list.yml
@@ -21,20 +21,4 @@ student.Profile:
   ".. no_pii:": "This model has no PII (it's fake)"
 student.ProgramCourseEnrollment:
   ".. no_pii:": "This model has no PII (it's fake)"
-djcelery.CrontabSchedule:
-  ".. no_pii:": "This model has no PII"
-djcelery.IntervalSchedule:
-  ".. no_pii:": "This model has no PII"
-djcelery.PeriodicTask:
-  ".. no_pii:": "This model has no PII"
-djcelery.PeriodicTasks:
-  ".. no_pii:": "This model has no PII"
-djcelery.TaskMeta:
-  ".. no_pii:": "This model has no PII"
-djcelery.TaskSetMeta:
-  ".. no_pii:": "This model has no PII"
-djcelery.TaskState:
-  ".. no_pii:": "This model has no PII"
-djcelery.WorkerState:
-  ".. no_pii:": "This model has no PII"
 

--- a/bulk_grades/settings/test.py
+++ b/bulk_grades/settings/test.py
@@ -9,3 +9,10 @@ def plugin_settings(settings):
         'url': 'mock',
         'token': 'edx'
     }
+
+
+# CELERY
+CELERY_ALWAYS_EAGER = True
+
+results_dir = tempfile.TemporaryDirectory()
+CELERY_RESULT_BACKEND = 'file://{}'.format(results_dir.name)

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -2,7 +2,6 @@
 -c constraints.txt
 
 Django              # Web application framework
-django-celery
 django-model-utils        # Provides TimeStampedModel abstract base class
 edx-opaque-keys
 super-csv

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,24 +4,22 @@
 #
 #    make upgrade
 #
-amqp==1.4.9               # via kombu
-anyjson==0.3.3            # via kombu
-billiard==3.3.0.23        # via celery
-celery==3.1.26.post2      # via django-celery, edx-celeryutils
+amqp==2.6.1               # via kombu
+billiard==3.5.0.5         # via celery
+celery==4.2.2             # via -c requirements/constraints.txt, edx-celeryutils
 certifi==2020.6.20        # via requests
 chardet==3.0.4            # via requests
-django-celery==3.3.1      # via -r requirements/base.in
 django-crum==0.7.7        # via super-csv
 django-model-utils==4.0.0  # via -r requirements/base.in, edx-celeryutils, super-csv
-django==2.2.15            # via -c requirements/constraints.txt, -r requirements/base.in, django-celery, django-crum, django-model-utils, djangorestframework, edx-celeryutils, jsonfield2, super-csv
+django==2.2.16            # via -c requirements/constraints.txt, -r requirements/base.in, django-crum, django-model-utils, djangorestframework, edx-celeryutils, jsonfield2, super-csv
 djangorestframework==3.11.1  # via super-csv
-edx-celeryutils==0.5.1    # via super-csv
+edx-celeryutils==0.5.2    # via super-csv
 edx-opaque-keys==2.1.1    # via -r requirements/base.in
 future==0.18.2            # via edx-celeryutils
 idna==2.10                # via requests
 jsonfield2==3.0.3         # via -c requirements/constraints.txt, edx-celeryutils
-kombu==3.0.37             # via celery
-pbr==5.4.5                # via stevedore
+kombu==4.3.0              # via celery
+pbr==5.5.0                # via stevedore
 pymongo==3.11.0           # via edx-opaque-keys
 pytz==2020.1              # via celery, django
 requests==2.24.0          # via -r requirements/base.in, slumber
@@ -32,3 +30,4 @@ sqlparse==0.3.1           # via django
 stevedore==1.32.0         # via -c requirements/constraints.txt, edx-opaque-keys
 super-csv==0.9.9          # via -r requirements/base.in
 urllib3==1.25.10          # via requests
+vine==1.3.0               # via amqp

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -26,3 +26,6 @@ twine<2.0
 
 # greater versions drops support for python 3.5
 stevedore<2.0
+
+
+celery<4.3     # Python 3.8 isn't officially supported until 4.4. Its a first steps towards latest celery version upgrade.

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,13 +4,12 @@
 #
 #    make upgrade
 #
-amqp==1.4.9               # via -r requirements/quality.txt, kombu
-anyjson==0.3.3            # via -r requirements/quality.txt, kombu
+amqp==2.6.1               # via -r requirements/quality.txt, kombu
 appdirs==1.4.4            # via -r requirements/travis.txt, virtualenv
 astroid==2.3.3            # via -r requirements/quality.txt, pylint, pylint-celery
 attrs==20.1.0             # via -r requirements/quality.txt, pytest
-billiard==3.3.0.23        # via -r requirements/quality.txt, celery
-celery==3.1.26.post2      # via -r requirements/quality.txt, django-celery, edx-celeryutils
+billiard==3.5.0.5         # via -r requirements/quality.txt, celery
+celery==4.2.2             # via -c requirements/constraints.txt, -r requirements/quality.txt, edx-celeryutils
 certifi==2020.6.20        # via -r requirements/quality.txt, -r requirements/travis.txt, requests
 chardet==3.0.4            # via -r requirements/quality.txt, -r requirements/travis.txt, requests
 click-log==0.3.2          # via -r requirements/quality.txt, edx-lint
@@ -19,14 +18,13 @@ code-annotations==0.5.1   # via -r requirements/quality.txt
 codecov==2.1.9            # via -r requirements/travis.txt
 coverage==5.2.1           # via -r requirements/quality.txt, -r requirements/travis.txt, codecov, pytest-cov
 ddt==1.4.1                # via -r requirements/quality.txt
-diff-cover==3.0.1         # via -r requirements/dev.in
+diff-cover==4.0.0         # via -r requirements/dev.in
 distlib==0.3.1            # via -r requirements/travis.txt, virtualenv
-django-celery==3.3.1      # via -r requirements/quality.txt
 django-crum==0.7.7        # via -r requirements/quality.txt, super-csv
 django-model-utils==4.0.0  # via -r requirements/quality.txt, edx-celeryutils, super-csv
-django==2.2.15            # via -c requirements/constraints.txt, -r requirements/quality.txt, code-annotations, django-celery, django-crum, django-model-utils, djangorestframework, edx-celeryutils, edx-i18n-tools, jsonfield2, super-csv
+django==2.2.16            # via -c requirements/constraints.txt, -r requirements/quality.txt, code-annotations, django-crum, django-model-utils, djangorestframework, edx-celeryutils, edx-i18n-tools, jsonfield2, super-csv
 djangorestframework==3.11.1  # via -r requirements/quality.txt, super-csv
-edx-celeryutils==0.5.1    # via -r requirements/quality.txt, super-csv
+edx-celeryutils==0.5.2    # via -r requirements/quality.txt, super-csv
 edx-i18n-tools==0.5.3     # via -r requirements/dev.in
 edx-lint==1.5.2           # via -r requirements/quality.txt
 edx-opaque-keys==2.1.1    # via -r requirements/quality.txt
@@ -41,23 +39,23 @@ isort==4.3.21             # via -r requirements/quality.txt, pylint
 jinja2-pluralize==0.3.0   # via diff-cover
 jinja2==2.11.2            # via -r requirements/quality.txt, code-annotations, diff-cover, jinja2-pluralize
 jsonfield2==3.0.3         # via -c requirements/constraints.txt, -r requirements/quality.txt, edx-celeryutils
-kombu==3.0.37             # via -r requirements/quality.txt, celery
+kombu==4.3.0              # via -r requirements/quality.txt, celery
 lazy-object-proxy==1.4.3  # via -r requirements/quality.txt, astroid
 markupsafe==1.1.1         # via -r requirements/quality.txt, jinja2
 mccabe==0.6.1             # via -r requirements/quality.txt, pylint
 mock==3.0.5               # via -c requirements/constraints.txt, -r requirements/quality.txt
-more-itertools==8.4.0     # via -r requirements/quality.txt, pytest
+more-itertools==8.5.0     # via -r requirements/quality.txt, pytest
 packaging==20.4           # via -r requirements/quality.txt, -r requirements/travis.txt, pytest, tox
 path.py==12.5.0           # via edx-i18n-tools
 path==13.1.0              # via path.py
 pathlib2==2.3.5           # via -r requirements/quality.txt, pytest
-pbr==5.4.5                # via -r requirements/quality.txt, stevedore
+pbr==5.5.0                # via -r requirements/quality.txt, stevedore
 pip-tools==5.3.1          # via -r requirements/pip-tools.txt
 pluggy==0.13.1            # via -r requirements/quality.txt, -r requirements/travis.txt, diff-cover, pytest, tox
 polib==1.1.0              # via edx-i18n-tools
 py==1.9.0                 # via -r requirements/quality.txt, -r requirements/travis.txt, pytest, tox
 pycodestyle==2.6.0        # via -r requirements/quality.txt
-pydocstyle==5.1.0         # via -r requirements/quality.txt
+pydocstyle==5.1.1         # via -r requirements/quality.txt
 pygments==2.6.1           # via diff-cover
 pylint-celery==0.3        # via -r requirements/quality.txt, edx-lint
 pylint-django==2.0.11     # via -r requirements/quality.txt, edx-lint
@@ -73,7 +71,7 @@ pytz==2020.1              # via -r requirements/quality.txt, celery, django
 pyyaml==5.3.1             # via -r requirements/quality.txt, code-annotations, edx-i18n-tools
 requests==2.24.0          # via -r requirements/quality.txt, -r requirements/travis.txt, codecov, slumber
 simplejson==3.17.2        # via -r requirements/quality.txt, super-csv
-six==1.15.0               # via -r requirements/pip-tools.txt, -r requirements/quality.txt, -r requirements/travis.txt, astroid, diff-cover, edx-i18n-tools, edx-lint, edx-opaque-keys, mock, packaging, pathlib2, pip-tools, stevedore, tox, virtualenv
+six==1.15.0               # via -r requirements/pip-tools.txt, -r requirements/quality.txt, -r requirements/travis.txt, astroid, edx-i18n-tools, edx-lint, edx-opaque-keys, mock, packaging, pathlib2, pip-tools, stevedore, tox, virtualenv
 slumber==0.7.1            # via -r requirements/quality.txt
 snowballstemmer==2.0.0    # via -r requirements/quality.txt, pydocstyle
 sqlparse==0.3.1           # via -r requirements/quality.txt, django
@@ -82,9 +80,10 @@ super-csv==0.9.9          # via -r requirements/quality.txt
 text-unidecode==1.3       # via -r requirements/quality.txt, python-slugify
 toml==0.10.1              # via -r requirements/quality.txt, -r requirements/travis.txt, pytest, tox
 tox-battery==0.6.1        # via -r requirements/travis.txt
-tox==3.19.0               # via -r requirements/travis.txt, tox-battery
+tox==3.20.0               # via -r requirements/travis.txt, tox-battery
 typed-ast==1.4.1          # via -r requirements/quality.txt, astroid
 urllib3==1.25.10          # via -r requirements/quality.txt, -r requirements/travis.txt, requests
+vine==1.3.0               # via -r requirements/quality.txt, amqp
 virtualenv==20.0.31       # via -r requirements/travis.txt, tox
 wrapt==1.11.2             # via -r requirements/quality.txt, astroid
 zipp==1.2.0               # via -c requirements/constraints.txt, -r requirements/quality.txt, -r requirements/travis.txt, importlib-metadata, importlib-resources

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -5,27 +5,25 @@
 #    make upgrade
 #
 alabaster==0.7.12         # via sphinx
-amqp==1.4.9               # via -r requirements/test.txt, kombu
-anyjson==0.3.3            # via -r requirements/test.txt, kombu
+amqp==2.6.1               # via -r requirements/test.txt, kombu
 attrs==20.1.0             # via -r requirements/test.txt, pytest
 babel==2.8.0              # via sphinx
-billiard==3.3.0.23        # via -r requirements/test.txt, celery
+billiard==3.5.0.5         # via -r requirements/test.txt, celery
 bleach==3.1.5             # via readme-renderer
-celery==3.1.26.post2      # via -r requirements/test.txt, django-celery, edx-celeryutils
+celery==4.2.2             # via -c requirements/constraints.txt, -r requirements/test.txt, edx-celeryutils
 certifi==2020.6.20        # via -r requirements/test.txt, requests
 chardet==3.0.4            # via -r requirements/test.txt, doc8, requests
 click==7.1.2              # via -r requirements/test.txt, code-annotations
 code-annotations==0.5.1   # via -r requirements/test.txt
 coverage==5.2.1           # via -r requirements/test.txt, pytest-cov
 ddt==1.4.1                # via -r requirements/test.txt
-django-celery==3.3.1      # via -r requirements/test.txt
 django-crum==0.7.7        # via -r requirements/test.txt, super-csv
 django-model-utils==4.0.0  # via -r requirements/test.txt, edx-celeryutils, super-csv
-django==2.2.15            # via -c requirements/constraints.txt, -r requirements/test.txt, code-annotations, django-celery, django-crum, django-model-utils, djangorestframework, edx-celeryutils, jsonfield2, super-csv
+django==2.2.16            # via -c requirements/constraints.txt, -r requirements/test.txt, code-annotations, django-crum, django-model-utils, djangorestframework, edx-celeryutils, jsonfield2, super-csv
 djangorestframework==3.11.1  # via -r requirements/test.txt, super-csv
 doc8==0.8.1               # via -r requirements/doc.in
 docutils==0.16            # via doc8, readme-renderer, restructuredtext-lint, sphinx
-edx-celeryutils==0.5.1    # via -r requirements/test.txt, super-csv
+edx-celeryutils==0.5.2    # via -r requirements/test.txt, super-csv
 edx-opaque-keys==2.1.1    # via -r requirements/test.txt
 edx-sphinx-theme==1.5.0   # via -r requirements/doc.in
 future==0.18.2            # via -r requirements/test.txt, edx-celeryutils
@@ -35,13 +33,13 @@ importlib-metadata==1.7.0  # via -r requirements/test.txt, pluggy, pytest
 iniconfig==1.0.1          # via -r requirements/test.txt, pytest
 jinja2==2.11.2            # via -r requirements/test.txt, code-annotations, sphinx
 jsonfield2==3.0.3         # via -c requirements/constraints.txt, -r requirements/test.txt, edx-celeryutils
-kombu==3.0.37             # via -r requirements/test.txt, celery
+kombu==4.3.0              # via -r requirements/test.txt, celery
 markupsafe==1.1.1         # via -r requirements/test.txt, jinja2
 mock==3.0.5               # via -c requirements/constraints.txt, -r requirements/test.txt
-more-itertools==8.4.0     # via -r requirements/test.txt, pytest
+more-itertools==8.5.0     # via -r requirements/test.txt, pytest
 packaging==20.4           # via -r requirements/test.txt, bleach, pytest, sphinx
 pathlib2==2.3.5           # via -r requirements/test.txt, pytest
-pbr==5.4.5                # via -r requirements/test.txt, stevedore
+pbr==5.5.0                # via -r requirements/test.txt, stevedore
 pkginfo==1.5.0.1          # via twine
 pluggy==0.13.1            # via -r requirements/test.txt, pytest
 py==1.9.0                 # via -r requirements/test.txt, pytest
@@ -77,6 +75,7 @@ toml==0.10.1              # via -r requirements/test.txt, pytest
 tqdm==4.48.2              # via twine
 twine==1.15.0             # via -c requirements/constraints.txt, -r requirements/doc.in
 urllib3==1.25.10          # via -r requirements/test.txt, requests
+vine==1.3.0               # via -r requirements/test.txt, amqp
 webencodings==0.5.1       # via bleach
 zipp==1.2.0               # via -c requirements/constraints.txt, -r requirements/test.txt, importlib-metadata
 

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -4,12 +4,11 @@
 #
 #    make upgrade
 #
-amqp==1.4.9               # via -r requirements/test.txt, kombu
-anyjson==0.3.3            # via -r requirements/test.txt, kombu
+amqp==2.6.1               # via -r requirements/test.txt, kombu
 astroid==2.3.3            # via pylint, pylint-celery
 attrs==20.1.0             # via -r requirements/test.txt, pytest
-billiard==3.3.0.23        # via -r requirements/test.txt, celery
-celery==3.1.26.post2      # via -r requirements/test.txt, django-celery, edx-celeryutils
+billiard==3.5.0.5         # via -r requirements/test.txt, celery
+celery==4.2.2             # via -c requirements/constraints.txt, -r requirements/test.txt, edx-celeryutils
 certifi==2020.6.20        # via -r requirements/test.txt, requests
 chardet==3.0.4            # via -r requirements/test.txt, requests
 click-log==0.3.2          # via edx-lint
@@ -17,12 +16,11 @@ click==7.1.2              # via -r requirements/test.txt, click-log, code-annota
 code-annotations==0.5.1   # via -r requirements/test.txt
 coverage==5.2.1           # via -r requirements/test.txt, pytest-cov
 ddt==1.4.1                # via -r requirements/test.txt
-django-celery==3.3.1      # via -r requirements/test.txt
 django-crum==0.7.7        # via -r requirements/test.txt, super-csv
 django-model-utils==4.0.0  # via -r requirements/test.txt, edx-celeryutils, super-csv
-django==2.2.15            # via -c requirements/constraints.txt, -r requirements/test.txt, code-annotations, django-celery, django-crum, django-model-utils, djangorestframework, edx-celeryutils, jsonfield2, super-csv
+django==2.2.16            # via -c requirements/constraints.txt, -r requirements/test.txt, code-annotations, django-crum, django-model-utils, djangorestframework, edx-celeryutils, jsonfield2, super-csv
 djangorestframework==3.11.1  # via -r requirements/test.txt, super-csv
-edx-celeryutils==0.5.1    # via -r requirements/test.txt, super-csv
+edx-celeryutils==0.5.2    # via -r requirements/test.txt, super-csv
 edx-lint==1.5.2           # via -r requirements/quality.in
 edx-opaque-keys==2.1.1    # via -r requirements/test.txt
 future==0.18.2            # via -r requirements/test.txt, edx-celeryutils
@@ -32,19 +30,19 @@ iniconfig==1.0.1          # via -r requirements/test.txt, pytest
 isort==4.3.21             # via -r requirements/quality.in, pylint
 jinja2==2.11.2            # via -r requirements/test.txt, code-annotations
 jsonfield2==3.0.3         # via -c requirements/constraints.txt, -r requirements/test.txt, edx-celeryutils
-kombu==3.0.37             # via -r requirements/test.txt, celery
+kombu==4.3.0              # via -r requirements/test.txt, celery
 lazy-object-proxy==1.4.3  # via astroid
 markupsafe==1.1.1         # via -r requirements/test.txt, jinja2
 mccabe==0.6.1             # via pylint
 mock==3.0.5               # via -c requirements/constraints.txt, -r requirements/test.txt
-more-itertools==8.4.0     # via -r requirements/test.txt, pytest
+more-itertools==8.5.0     # via -r requirements/test.txt, pytest
 packaging==20.4           # via -r requirements/test.txt, pytest
 pathlib2==2.3.5           # via -r requirements/test.txt, pytest
-pbr==5.4.5                # via -r requirements/test.txt, stevedore
+pbr==5.5.0                # via -r requirements/test.txt, stevedore
 pluggy==0.13.1            # via -r requirements/test.txt, pytest
 py==1.9.0                 # via -r requirements/test.txt, pytest
 pycodestyle==2.6.0        # via -r requirements/quality.in
-pydocstyle==5.1.0         # via -r requirements/quality.in
+pydocstyle==5.1.1         # via -r requirements/quality.in
 pylint-celery==0.3        # via edx-lint
 pylint-django==2.0.11     # via edx-lint
 pylint-plugin-utils==0.6  # via pylint-celery, pylint-django
@@ -69,5 +67,6 @@ text-unidecode==1.3       # via -r requirements/test.txt, python-slugify
 toml==0.10.1              # via -r requirements/test.txt, pytest
 typed-ast==1.4.1          # via astroid
 urllib3==1.25.10          # via -r requirements/test.txt, requests
+vine==1.3.0               # via -r requirements/test.txt, amqp
 wrapt==1.11.2             # via astroid
 zipp==1.2.0               # via -c requirements/constraints.txt, -r requirements/test.txt, importlib-metadata

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,22 +4,20 @@
 #
 #    make upgrade
 #
-amqp==1.4.9               # via -r requirements/base.txt, kombu
-anyjson==0.3.3            # via -r requirements/base.txt, kombu
+amqp==2.6.1               # via -r requirements/base.txt, kombu
 attrs==20.1.0             # via pytest
-billiard==3.3.0.23        # via -r requirements/base.txt, celery
-celery==3.1.26.post2      # via -r requirements/base.txt, django-celery, edx-celeryutils
+billiard==3.5.0.5         # via -r requirements/base.txt, celery
+celery==4.2.2             # via -c requirements/constraints.txt, -r requirements/base.txt, edx-celeryutils
 certifi==2020.6.20        # via -r requirements/base.txt, requests
 chardet==3.0.4            # via -r requirements/base.txt, requests
 click==7.1.2              # via code-annotations
 code-annotations==0.5.1   # via -r requirements/test.in
 coverage==5.2.1           # via pytest-cov
 ddt==1.4.1                # via -r requirements/test.in
-django-celery==3.3.1      # via -r requirements/base.txt
 django-crum==0.7.7        # via -r requirements/base.txt, super-csv
 django-model-utils==4.0.0  # via -r requirements/base.txt, edx-celeryutils, super-csv
 djangorestframework==3.11.1  # via -r requirements/base.txt, super-csv
-edx-celeryutils==0.5.1    # via -r requirements/base.txt, super-csv
+edx-celeryutils==0.5.2    # via -r requirements/base.txt, super-csv
 edx-opaque-keys==2.1.1    # via -r requirements/base.txt
 future==0.18.2            # via -r requirements/base.txt, edx-celeryutils
 idna==2.10                # via -r requirements/base.txt, requests
@@ -27,13 +25,13 @@ importlib-metadata==1.7.0  # via pluggy, pytest
 iniconfig==1.0.1          # via pytest
 jinja2==2.11.2            # via code-annotations
 jsonfield2==3.0.3         # via -c requirements/constraints.txt, -r requirements/base.txt, edx-celeryutils
-kombu==3.0.37             # via -r requirements/base.txt, celery
+kombu==4.3.0              # via -r requirements/base.txt, celery
 markupsafe==1.1.1         # via jinja2
 mock==3.0.5               # via -c requirements/constraints.txt, -r requirements/test.in
-more-itertools==8.4.0     # via pytest
+more-itertools==8.5.0     # via pytest
 packaging==20.4           # via pytest
 pathlib2==2.3.5           # via pytest
-pbr==5.4.5                # via -r requirements/base.txt, stevedore
+pbr==5.5.0                # via -r requirements/base.txt, stevedore
 pluggy==0.13.1            # via pytest
 py==1.9.0                 # via pytest
 pymongo==3.11.0           # via -r requirements/base.txt, edx-opaque-keys
@@ -54,4 +52,5 @@ super-csv==0.9.9          # via -r requirements/base.txt
 text-unidecode==1.3       # via python-slugify
 toml==0.10.1              # via pytest
 urllib3==1.25.10          # via -r requirements/base.txt, requests
+vine==1.3.0               # via -r requirements/base.txt, amqp
 zipp==1.2.0               # via -c requirements/constraints.txt, importlib-metadata

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -22,7 +22,7 @@ requests==2.24.0          # via codecov
 six==1.15.0               # via packaging, tox, virtualenv
 toml==0.10.1              # via tox
 tox-battery==0.6.1        # via -r requirements/travis.in
-tox==3.19.0               # via -r requirements/travis.in, tox-battery
+tox==3.20.0               # via -r requirements/travis.in, tox-battery
 urllib3==1.25.10          # via requests
 virtualenv==20.0.31       # via tox
 zipp==1.2.0               # via -c requirements/constraints.txt, importlib-metadata, importlib-resources

--- a/test_settings.py
+++ b/test_settings.py
@@ -59,4 +59,6 @@ MIDDLEWARE = (
     'django.contrib.auth.middleware.AuthenticationMiddleware',
 )
 
+CELERY_ALWAYS_EAGER = True
+
 

--- a/test_settings.py
+++ b/test_settings.py
@@ -7,8 +7,6 @@ Django applications, so these settings will not be used.
 
 from os.path import abspath, dirname, join
 
-import djcelery
-
 
 def root(*args):
     """
@@ -38,7 +36,6 @@ INSTALLED_APPS = (
     'super_csv',
     'courseware.apps.CoursewareConfig',
     'student',
-    'djcelery',
 )
 
 LOCALE_PATHS = [
@@ -61,11 +58,5 @@ MIDDLEWARE = (
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
 )
-CELERY_ALWAYS_EAGER = True
-CELERY_RESULT_BACKEND = 'djcelery.backends.cache:CacheBackend'
-CELERY_EAGER_PROPAGATES_EXCEPTIONS = False
-CELERY_BROKER_URL = BROKER_URL = 'memory://'
-CELERY_BROKER_TRANSPORT = 'memory://'
-CELERY_BROKER_HOSTNAME = 'localhost'
 
-djcelery.setup_loader()
+

--- a/test_settings.py
+++ b/test_settings.py
@@ -61,4 +61,5 @@ MIDDLEWARE = (
 
 CELERY_ALWAYS_EAGER = True
 
-
+results_dir = tempfile.TemporaryDirectory()
+CELERY_RESULT_BACKEND = 'file://{}'.format(results_dir.name)


### PR DESCRIPTION
upgrade celery to 4.2.2

**Description:** Describe in a couple of sentences what this PR adds

**JIRA:** Link to JIRA ticket

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)
