### PR TITLE
EDUCATOR-5401: CSV download includes inactive enrollments

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,11 @@ Unreleased
 ~~~~~~~~~~
 *
 
+[0.8.2] - 2020-11-02
+~~~~~~~~~~~~~~~~~~~~~
+* Added ``active_only`` field to ``GradeCSVProcessor``
+* For Grade CSV bulk download, only include active enrollments
+
 [0.8.0] - 2020-09-03
 ~~~~~~~~~~~~~~~~~~~~~
 * Upgraded to celery 4.2.2

--- a/bulk_grades/__init__.py
+++ b/bulk_grades/__init__.py
@@ -2,6 +2,6 @@
 Support for bulk scoring and grading.
 """
 
-__version__ = '0.8.1'
+__version__ = '0.8.2'
 
 default_app_config = 'bulk_grades.apps.BulkGradesConfig'  # pylint: disable=invalid-name

--- a/bulk_grades/views.py
+++ b/bulk_grades/views.py
@@ -133,6 +133,7 @@ class GradeImportExport(GradeOnlyExport):
                                       if assignment_grade_min else None),
                 course_grade_min=(float(course_grade_min) if course_grade_min else None),
                 course_grade_max=(float(course_grade_max) if course_grade_max else None),
+                active_only=True,
             )
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -262,6 +262,7 @@ def mock_subsection_grade(grade_iter):
     return f
 
 
+@ddt.ddt
 class TestGradeProcessor(BaseTests):
     """
     Tests exercising the processing performed by GradeCSVProcessor
@@ -283,8 +284,9 @@ class TestGradeProcessor(BaseTests):
         assert 'verified@example.com,,' in verified_row[0]
         assert len(rows) == self.NUM_USERS + 1
 
+    @ddt.data(True, False)
     @patch('lms.djangoapps.grades.api.CourseGradeFactory.read', return_value=Mock(percent=0.50))
-    def test_export__inactive_learner(self, course_grade_factory_mock):  # pylint: disable=unused-argument
+    def test_export__inactive_learner(self, active_only, course_grade_factory_mock):  # pylint: disable=unused-argument
         # Create a learner, then get her PCE and deactivate it, which will deactivate the CourseEnrollment as well
         inactive_learner = User.objects.create(username='inactive_learner')
         Profile.objects.create(user=inactive_learner, name="Ina Ctive-Learner")
@@ -299,13 +301,17 @@ class TestGradeProcessor(BaseTests):
         course_enrollment.save()
 
         # Get csv file and grab row 
-        processor = api.GradeCSVProcessor(course_id=self.course_id)
+        processor = api.GradeCSVProcessor(course_id=self.course_id, active_only=active_only)
         rows = list(processor.get_iterator())
         inactive_row = [row for row in rows if 'inactive_learner' in row]
 
-        # Assert that inactive learner is still present in the CSV export
-        assert len(inactive_row) == 1
-        assert 'inactive_learner,ext:6' in inactive_row[0]
+        if active_only:
+            # Assert that inactive learner is not present is CSV
+            assert len(inactive_row) == 0
+        else:
+            # Assert that inactive learner is still present in the CSV export
+            assert len(inactive_row) == 1
+            assert 'inactive_learner,ext:6' in inactive_row[0]
 
     @patch('lms.djangoapps.grades.api.graded_subsections_for_course_id')
     def test_columns_not_duplicated_during_init(self, mock_graded_subsections):


### PR DESCRIPTION
**Description:** We were including inactive learners in the bulk grades csv export. We don't want to do this.

**JIRA:** [EDUCATOR-5401](https://openedx.atlassian.net/browse/EDUCATOR-5401)

**Merge checklist:**
- [x] All reviewers approved
- [x] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)
