### PR TITLE
Updated the build status badge to point to travis-ci.com

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,10 @@ Unreleased
 ~~~~~~~~~~
 *
 
+[0.8.3] - 2020-11-19
+~~~~~~~~~~~~~~~~~~~~~
+* Updated the build status badge in README.rst to point to travis-ci.com instead of travis-ci.org
+
 [0.8.2] - 2020-11-02
 ~~~~~~~~~~~~~~~~~~~~~
 * Added ``active_only`` field to ``GradeCSVProcessor``

--- a/README.rst
+++ b/README.rst
@@ -111,8 +111,8 @@ refer to this `list of resources`_ if you need any assistance.
     :target: https://pypi.python.org/pypi/edx-bulk-grades/
     :alt: PyPI
 
-.. |travis-badge| image:: https://travis-ci.org/edx/edx-bulk-grades.svg?branch=master
-    :target: https://travis-ci.org/edx/edx-bulk-grades
+.. |travis-badge| image:: https://travis-ci.com/edx/edx-bulk-grades.svg?branch=master
+    :target: https://travis-ci.com/edx/edx-bulk-grades
     :alt: Travis
 
 .. |codecov-badge| image:: http://codecov.io/github/edx/edx-bulk-grades/coverage.svg?branch=master

--- a/bulk_grades/__init__.py
+++ b/bulk_grades/__init__.py
@@ -2,6 +2,6 @@
 Support for bulk scoring and grading.
 """
 
-__version__ = '0.8.2'
+__version__ = '0.8.3'
 
 default_app_config = 'bulk_grades.apps.BulkGradesConfig'  # pylint: disable=invalid-name


### PR DESCRIPTION
Updated the README file.
Build status badge is now pointing to 'travis-ci.com' instead of 'travis-ci.org'

JIRA: https://openedx.atlassian.net/browse/BOM-2089