### PR TITLE
Added celery 5.0 for testing purpose

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,13 @@
 language: python
 dist: xenial
 python:
-  - 3.5
   - 3.8
 env:
-  - TOXENV=django22
+  - TOXENV=django22-celery44
+  - TOXENV=django22-celery50
   - TOXENV=quality
   - TOXENV=docs
   - TOXENV=pii_check
-
 cache:
   - pip
 before_install:
@@ -26,7 +25,7 @@ deploy:
   distributions: sdist bdist_wheel
   on:
     tags: true
-    python: 3.5
+    python: 3.8
     condition: "$TOXENV = quality"
   password:
     secure: fqghurmaw5AV4v5e8udqjAhAppWax9cIof2nkKjVREIxURLuaAESFHg40fvA7q6eHsvZoXf34HIoFw2s7HBMe3dtYo4i+wY4JsMYyBPUGV3koSJe3ODwlx8A1IRv2i/WCDtfoFS8jZdeu02OQ6LHbf2P+Kmv3cX5qVCUez+E9bTBniPIqMd9MdA7bN5ft6BYcQttbxvK7sPRJ7Gkv+zKQdXjMpH/v9jjK5f4rAAtqHICymDrwurU7l01964TLTyyHKnB5kZNaTVc/nLMlU1gHSnO5wS7i3BJuzpI/2rjiIIaZJgQJA3U1wj5hHm0R9X7Bo4RSDv5i9Lrf6TPhArqORf6Nk5iLbMPRCCdUV99HkbV6rGJU8DjKFxdnbyBgQlAlQ0rSl0kx2pjtgcMk4JPez/E8JTpruj/J001MvmoK8KoceCIelDDNQRrUYwPldyUv8eB5GSttmtWWXiedHZwk/iyhLknEKCK8jt2s2H4OGlxaXppBSVMRJBJ8ylUpYfFcxwIiHp7A0tYgxUBSmWxGcx0iowrVwQ2AQxzAykd07au7Yt3ge2YI3tEtm6dvHXj/fYi3iuukCv+Nj853JbGN2sfBssmpfOmJEG0ezwQgVKcc19+6RB+CH1YfBnMqR1xPB5D8+EMUHPbPI0akgfXSM1133EJ1KUoG5pSDe8h804=

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,10 @@ Unreleased
 ~~~~~~~~~~
 *
 
+[0.8.4] - 2020-12-24
+~~~~~~~~~~~~~~~~~~~~~
+* Adding celery5.0 testing using tox.
+
 [0.8.3] - 2020-11-19
 ~~~~~~~~~~~~~~~~~~~~~
 * Updated the build status badge in README.rst to point to travis-ci.com instead of travis-ci.org

--- a/Makefile
+++ b/Makefile
@@ -39,10 +39,19 @@ upgrade: ## update the requirements/*.txt files with the latest packages satisfy
 	pip-compile --upgrade -o requirements/doc.txt requirements/doc.in
 	pip-compile --upgrade -o requirements/quality.txt requirements/quality.in
 	pip-compile --upgrade -o requirements/travis.txt requirements/travis.in
+	pip-compile --upgrade -o requirements/pii_check.txt requirements/pii_check.in
 	pip-compile --upgrade -o requirements/dev.txt requirements/dev.in
-	# Let tox control the Django version for tests
+	# Let tox control the Django,celery versions for tests
 	sed '/^[dD]jango==/d' requirements/test.txt > requirements/test.tmp
 	mv requirements/test.tmp requirements/test.txt
+	grep -e "^amqp==\|^anyjson==\|^billiard==\|^celery==\|^kombu==\|^click-didyoumean==\|^click-repl==\|^click==\|^prompt-toolkit==\|^vine==" requirements/base.txt > requirements/celery44.txt
+	sed -i.tmp '/^amqp==/d' requirements/test.txt
+	sed -i.tmp '/^anyjson==/d' requirements/test.txt
+	sed -i.tmp '/^billiard==/d' requirements/test.txt
+	sed -i.tmp '/^celery==/d' requirements/test.txt
+	sed -i.tmp '/^kombu==/d' requirements/test.txt
+	sed -i.tmp '/^vine==/d' requirements/test.txt
+	rm requirements/*.txt.tmp
 
 quality: ## check coding style with pycodestyle and pylint
 	tox -e quality

--- a/bulk_grades/__init__.py
+++ b/bulk_grades/__init__.py
@@ -2,6 +2,6 @@
 Support for bulk scoring and grading.
 """
 
-__version__ = '0.8.3'
+__version__ = '0.8.4'
 
 default_app_config = 'bulk_grades.apps.BulkGradesConfig'  # pylint: disable=invalid-name

--- a/bulk_grades/clients.py
+++ b/bulk_grades/clients.py
@@ -64,7 +64,7 @@ class LearnerAPIClient(API):
             ]
         )
         log.info('base url: %s', settings.ANALYTICS_API_CLIENT.get('url'))
-        super(LearnerAPIClient, self).__init__(
+        super().__init__(
             settings.ANALYTICS_API_CLIENT.get('url'),
             session=session,
             auth=TokenAuth(settings.ANALYTICS_API_CLIENT.get('token')),

--- a/bulk_grades/views.py
+++ b/bulk_grades/views.py
@@ -22,7 +22,7 @@ class GradeOnlyExport(View):
         """
         Configure initial state.
         """
-        super(GradeOnlyExport, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         self.processor = None
         self.extra_filename = ''
 
@@ -42,8 +42,9 @@ class GradeOnlyExport(View):
         Dispatch django request.
         """
         self.initialize_processor(request, course_id)
-        return super(GradeOnlyExport, self).dispatch(request, course_id, *args, **kwargs)
+        return super().dispatch(request, course_id, *args, **kwargs)
 
+    # pylint: disable=unused-argument
     def get(self, request, course_id, *args, **kwargs):
         """
         Export grades in CSV format.
@@ -72,6 +73,7 @@ class GradeImportExport(GradeOnlyExport):
     CSV Grade import/export view.
     """
 
+    # pylint: disable=unused-argument
     def post(self, request, course_id, *args, **kwargs):
         """
         Import grades from a CSV file.

--- a/manage.py
+++ b/manage.py
@@ -20,11 +20,11 @@ if __name__ == '__main__':
         # exceptions on Python 2.
         try:
             import django  # pylint: disable=unused-import
-        except ImportError:
+        except ImportError as error:
             raise ImportError(
                 "Couldn't import Django. Are you sure it's installed and "
                 "available on your PYTHONPATH environment variable? Did you "
                 "forget to activate a virtual environment?"
-            )
+            ) from error
         raise
     execute_from_command_line(sys.argv)

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -5,10 +5,10 @@
 #    make upgrade
 #
 amqp==2.6.1               # via kombu
-billiard==3.5.0.5         # via celery
-celery==4.2.2             # via -c requirements/constraints.txt, edx-celeryutils
+billiard==3.6.3.0         # via celery
+celery==4.4.7             # via -c requirements/constraints.txt, edx-celeryutils
 certifi==2020.12.5        # via requests
-chardet==3.0.4            # via requests
+chardet==4.0.0            # via requests
 django-crum==0.7.9        # via edx-django-utils, super-csv
 django-model-utils==4.1.1  # via -r requirements/base.in, edx-celeryutils, super-csv
 django-waffle==2.0.0      # via edx-django-utils
@@ -20,18 +20,18 @@ edx-opaque-keys==2.1.1    # via -r requirements/base.in
 future==0.18.2            # via edx-celeryutils
 idna==2.10                # via requests
 jsonfield2==3.0.3         # via -c requirements/constraints.txt, edx-celeryutils
-kombu==4.3.0              # via celery
-newrelic==5.22.1.152      # via edx-django-utils
+kombu==4.6.11             # via celery
+newrelic==5.24.0.153      # via edx-django-utils
 pbr==5.5.1                # via stevedore
-psutil==5.7.3             # via edx-django-utils
+psutil==5.8.0             # via edx-django-utils
 pymongo==3.11.2           # via edx-opaque-keys
 pytz==2020.4              # via celery, django
-requests==2.25.0          # via -r requirements/base.in, slumber
+requests==2.25.1          # via -r requirements/base.in, slumber
 simplejson==3.17.2        # via super-csv
 six==1.15.0               # via -r requirements/base.in, edx-opaque-keys, stevedore
 slumber==0.7.1            # via -r requirements/base.in
 sqlparse==0.4.1           # via django
 stevedore==1.32.0         # via -c requirements/constraints.txt, edx-django-utils, edx-opaque-keys
-super-csv==1.1.0          # via -r requirements/base.in
+super-csv==2.0.0          # via -r requirements/base.in
 urllib3==1.26.2           # via requests
-vine==1.3.0               # via amqp
+vine==1.3.0               # via amqp, celery

--- a/requirements/celery44.txt
+++ b/requirements/celery44.txt
@@ -1,0 +1,5 @@
+amqp==2.6.1               # via kombu
+billiard==3.6.3.0         # via celery
+celery==4.4.7             # via -c requirements/constraints.txt, edx-celeryutils
+kombu==4.6.11             # via celery
+vine==1.3.0               # via amqp, celery

--- a/requirements/celery50.txt
+++ b/requirements/celery50.txt
@@ -1,0 +1,9 @@
+amqp==5.0.2               # via kombu
+billiard==3.6.3.0         # via celery
+celery==5.0.5             # via edx-celeryutils
+click-didyoumean==0.0.3   # via celery
+click-repl==0.1.6         # via celery
+click==7.1.2              # via celery, click-didyoumean, click-plugins, click-repl
+kombu==5.0.2              # via celery
+prompt-toolkit==3.0.8     # via click-repl
+vine==5.0.0               # via amqp, celery

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -27,5 +27,5 @@ twine<2.0
 # greater versions drops support for python 3.5
 stevedore<2.0
 
-# Python 3.8 isn't officially supported until 4.4 and 4.3 requires redis version 3.2.0 or above.
-celery<4.3
+# Keeping celery 4.4.7 in the production currently
+celery<5.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -6,17 +6,17 @@
 #
 amqp==2.6.1               # via -r requirements/quality.txt, kombu
 appdirs==1.4.4            # via -r requirements/travis.txt, virtualenv
-astroid==2.3.3            # via -r requirements/quality.txt, pylint, pylint-celery
+astroid==2.4.2            # via -r requirements/quality.txt, pylint, pylint-celery
 attrs==20.3.0             # via -r requirements/quality.txt, pytest
-billiard==3.5.0.5         # via -r requirements/quality.txt, celery
-celery==4.2.2             # via -c requirements/constraints.txt, -r requirements/quality.txt, edx-celeryutils
+billiard==3.6.3.0         # via -r requirements/quality.txt, celery
+celery==4.4.7             # via -c requirements/constraints.txt, -r requirements/quality.txt, edx-celeryutils
 certifi==2020.12.5        # via -r requirements/quality.txt, -r requirements/travis.txt, requests
-chardet==3.0.4            # via -r requirements/quality.txt, -r requirements/travis.txt, requests
+chardet==4.0.0            # via -r requirements/quality.txt, -r requirements/travis.txt, requests
 click-log==0.3.2          # via -r requirements/quality.txt, edx-lint
 click==7.1.2              # via -r requirements/pip-tools.txt, -r requirements/quality.txt, click-log, code-annotations, edx-lint, pip-tools
 code-annotations==0.10.2  # via -r requirements/quality.txt
-codecov==2.1.10           # via -r requirements/travis.txt
-coverage==5.3             # via -r requirements/quality.txt, -r requirements/travis.txt, codecov, pytest-cov
+codecov==2.1.11           # via -r requirements/travis.txt
+coverage==5.3.1           # via -r requirements/quality.txt, -r requirements/travis.txt, codecov, pytest-cov
 ddt==1.4.1                # via -r requirements/quality.txt
 diff-cover==4.0.1         # via -r requirements/dev.in
 distlib==0.3.1            # via -r requirements/travis.txt, virtualenv
@@ -28,68 +28,63 @@ djangorestframework==3.12.2  # via -r requirements/quality.txt, super-csv
 edx-celeryutils==0.5.2    # via -r requirements/quality.txt, super-csv
 edx-django-utils==3.13.0  # via -r requirements/quality.txt, super-csv
 edx-i18n-tools==0.5.3     # via -r requirements/dev.in
-edx-lint==1.5.2           # via -r requirements/quality.txt
+edx-lint==1.6             # via -r requirements/quality.txt
 edx-opaque-keys==2.1.1    # via -r requirements/quality.txt
 filelock==3.0.12          # via -r requirements/travis.txt, tox, virtualenv
 future==0.18.2            # via -r requirements/quality.txt, edx-celeryutils
 idna==2.10                # via -r requirements/quality.txt, -r requirements/travis.txt, requests
-importlib-metadata==2.1.1  # via -r requirements/quality.txt, -r requirements/travis.txt, inflect, path, pluggy, pytest, tox, virtualenv
-importlib-resources==3.2.1  # via -r requirements/travis.txt, virtualenv
-inflect==3.0.2            # via jinja2-pluralize
+inflect==5.0.2            # via jinja2-pluralize
 iniconfig==1.1.1          # via -r requirements/quality.txt, pytest
-isort==4.3.21             # via -r requirements/quality.txt, pylint
+isort==5.6.4              # via -r requirements/quality.txt, pylint
 jinja2-pluralize==0.3.0   # via diff-cover
 jinja2==2.11.2            # via -r requirements/quality.txt, code-annotations, diff-cover, jinja2-pluralize
 jsonfield2==3.0.3         # via -c requirements/constraints.txt, -r requirements/quality.txt, edx-celeryutils
-kombu==4.3.0              # via -r requirements/quality.txt, celery
+kombu==4.6.11             # via -r requirements/quality.txt, celery
 lazy-object-proxy==1.4.3  # via -r requirements/quality.txt, astroid
 markupsafe==1.1.1         # via -r requirements/quality.txt, jinja2
 mccabe==0.6.1             # via -r requirements/quality.txt, pylint
 mock==3.0.5               # via -c requirements/constraints.txt, -r requirements/quality.txt
-newrelic==5.22.1.152      # via -r requirements/quality.txt, edx-django-utils
-packaging==20.7           # via -r requirements/quality.txt, -r requirements/travis.txt, pytest, tox
+newrelic==5.24.0.153      # via -r requirements/quality.txt, edx-django-utils
+packaging==20.8           # via -r requirements/quality.txt, -r requirements/travis.txt, pytest, tox
 path.py==12.5.0           # via edx-i18n-tools
-path==13.1.0              # via path.py
-pathlib2==2.3.5           # via -r requirements/quality.txt, pytest
+path==15.0.1              # via path.py
 pbr==5.5.1                # via -r requirements/quality.txt, stevedore
 pip-tools==5.4.0          # via -r requirements/pip-tools.txt
 pluggy==0.13.1            # via -r requirements/quality.txt, -r requirements/travis.txt, diff-cover, pytest, tox
 polib==1.1.0              # via edx-i18n-tools
-psutil==5.7.3             # via -r requirements/quality.txt, edx-django-utils
-py==1.9.0                 # via -r requirements/quality.txt, -r requirements/travis.txt, pytest, tox
+psutil==5.8.0             # via -r requirements/quality.txt, edx-django-utils
+py==1.10.0                # via -r requirements/quality.txt, -r requirements/travis.txt, pytest, tox
 pycodestyle==2.6.0        # via -r requirements/quality.txt
 pydocstyle==5.1.1         # via -r requirements/quality.txt
 pygments==2.7.3           # via diff-cover
 pylint-celery==0.3        # via -r requirements/quality.txt, edx-lint
-pylint-django==2.0.11     # via -r requirements/quality.txt, edx-lint
+pylint-django==2.3.0      # via -r requirements/quality.txt, edx-lint
 pylint-plugin-utils==0.6  # via -r requirements/quality.txt, pylint-celery, pylint-django
-pylint==2.4.4             # via -r requirements/quality.txt, edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
+pylint==2.6.0             # via -r requirements/quality.txt, edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
 pymongo==3.11.2           # via -r requirements/quality.txt, edx-opaque-keys
 pyparsing==2.4.7          # via -r requirements/quality.txt, -r requirements/travis.txt, packaging
 pytest-cov==2.10.1        # via -r requirements/quality.txt
 pytest-django==4.1.0      # via -r requirements/quality.txt
-pytest==6.1.2             # via -r requirements/quality.txt, pytest-cov, pytest-django
+pytest==6.2.1             # via -r requirements/quality.txt, pytest-cov, pytest-django
 python-slugify==4.0.1     # via -r requirements/quality.txt, code-annotations
 pytz==2020.4              # via -r requirements/quality.txt, celery, django
 pyyaml==5.3.1             # via -r requirements/quality.txt, code-annotations, edx-i18n-tools
-requests==2.25.0          # via -r requirements/quality.txt, -r requirements/travis.txt, codecov, slumber
+requests==2.25.1          # via -r requirements/quality.txt, -r requirements/travis.txt, codecov, slumber
 simplejson==3.17.2        # via -r requirements/quality.txt, super-csv
-six==1.15.0               # via -r requirements/pip-tools.txt, -r requirements/quality.txt, -r requirements/travis.txt, astroid, edx-i18n-tools, edx-lint, edx-opaque-keys, mock, pathlib2, pip-tools, stevedore, tox, virtualenv
+six==1.15.0               # via -r requirements/pip-tools.txt, -r requirements/quality.txt, -r requirements/travis.txt, astroid, edx-i18n-tools, edx-lint, edx-opaque-keys, mock, pip-tools, stevedore, tox, virtualenv
 slumber==0.7.1            # via -r requirements/quality.txt
 snowballstemmer==2.0.0    # via -r requirements/quality.txt, pydocstyle
 sqlparse==0.4.1           # via -r requirements/quality.txt, django
 stevedore==1.32.0         # via -c requirements/constraints.txt, -r requirements/quality.txt, code-annotations, edx-django-utils, edx-opaque-keys
-super-csv==1.1.0          # via -r requirements/quality.txt
+super-csv==2.0.0          # via -r requirements/quality.txt
 text-unidecode==1.3       # via -r requirements/quality.txt, python-slugify
-toml==0.10.2              # via -r requirements/quality.txt, -r requirements/travis.txt, pytest, tox
+toml==0.10.2              # via -r requirements/quality.txt, -r requirements/travis.txt, pylint, pytest, tox
 tox-battery==0.6.1        # via -r requirements/travis.txt
 tox==3.20.1               # via -r requirements/travis.txt, tox-battery
-typed-ast==1.4.1          # via -r requirements/quality.txt, astroid
 urllib3==1.26.2           # via -r requirements/quality.txt, -r requirements/travis.txt, requests
-vine==1.3.0               # via -r requirements/quality.txt, amqp
+vine==1.3.0               # via -r requirements/quality.txt, amqp, celery
 virtualenv==20.2.2        # via -r requirements/travis.txt, tox
-wrapt==1.11.2             # via -r requirements/quality.txt, astroid
-zipp==1.2.0               # via -c requirements/constraints.txt, -r requirements/quality.txt, -r requirements/travis.txt, importlib-metadata, importlib-resources
+wrapt==1.12.1             # via -r requirements/quality.txt, astroid
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -8,14 +8,14 @@ alabaster==0.7.12         # via sphinx
 amqp==2.6.1               # via -r requirements/test.txt, kombu
 attrs==20.3.0             # via -r requirements/test.txt, pytest
 babel==2.9.0              # via sphinx
-billiard==3.5.0.5         # via -r requirements/test.txt, celery
+billiard==3.6.3.0         # via -r requirements/test.txt, celery
 bleach==3.2.1             # via readme-renderer
-celery==4.2.2             # via -c requirements/constraints.txt, -r requirements/test.txt, edx-celeryutils
+celery==4.4.7             # via -c requirements/constraints.txt, -r requirements/test.txt, edx-celeryutils
 certifi==2020.12.5        # via -r requirements/test.txt, requests
-chardet==3.0.4            # via -r requirements/test.txt, doc8, requests
+chardet==4.0.0            # via -r requirements/test.txt, doc8, requests
 click==7.1.2              # via -r requirements/test.txt, code-annotations
 code-annotations==0.10.2  # via -r requirements/test.txt
-coverage==5.3             # via -r requirements/test.txt, pytest-cov
+coverage==5.3.1           # via -r requirements/test.txt, pytest-cov
 ddt==1.4.1                # via -r requirements/test.txt
 django-crum==0.7.9        # via -r requirements/test.txt, edx-django-utils, super-csv
 django-model-utils==4.1.1  # via -r requirements/test.txt, edx-celeryutils, super-csv
@@ -27,43 +27,41 @@ docutils==0.16            # via doc8, readme-renderer, restructuredtext-lint, sp
 edx-celeryutils==0.5.2    # via -r requirements/test.txt, super-csv
 edx-django-utils==3.13.0  # via -r requirements/test.txt, super-csv
 edx-opaque-keys==2.1.1    # via -r requirements/test.txt
-edx-sphinx-theme==1.5.0   # via -r requirements/doc.in
+edx-sphinx-theme==1.6.0   # via -r requirements/doc.in
 future==0.18.2            # via -r requirements/test.txt, edx-celeryutils
 idna==2.10                # via -r requirements/test.txt, requests
 imagesize==1.2.0          # via sphinx
-importlib-metadata==2.1.1  # via -r requirements/test.txt, pluggy, pytest
 iniconfig==1.1.1          # via -r requirements/test.txt, pytest
 jinja2==2.11.2            # via -r requirements/test.txt, code-annotations, sphinx
 jsonfield2==3.0.3         # via -c requirements/constraints.txt, -r requirements/test.txt, edx-celeryutils
-kombu==4.3.0              # via -r requirements/test.txt, celery
+kombu==4.6.11             # via -r requirements/test.txt, celery
 markupsafe==1.1.1         # via -r requirements/test.txt, jinja2
 mock==3.0.5               # via -c requirements/constraints.txt, -r requirements/test.txt
-newrelic==5.22.1.152      # via -r requirements/test.txt, edx-django-utils
-packaging==20.7           # via -r requirements/test.txt, bleach, pytest, sphinx
-pathlib2==2.3.5           # via -r requirements/test.txt, pytest
+newrelic==5.24.0.153      # via -r requirements/test.txt, edx-django-utils
+packaging==20.8           # via -r requirements/test.txt, bleach, pytest, sphinx
 pbr==5.5.1                # via -r requirements/test.txt, stevedore
 pkginfo==1.6.1            # via twine
 pluggy==0.13.1            # via -r requirements/test.txt, pytest
-psutil==5.7.3             # via -r requirements/test.txt, edx-django-utils
-py==1.9.0                 # via -r requirements/test.txt, pytest
+psutil==5.8.0             # via -r requirements/test.txt, edx-django-utils
+py==1.10.0                # via -r requirements/test.txt, pytest
 pygments==2.7.3           # via doc8, readme-renderer, sphinx
 pymongo==3.11.2           # via -r requirements/test.txt, edx-opaque-keys
 pyparsing==2.4.7          # via -r requirements/test.txt, packaging
 pytest-cov==2.10.1        # via -r requirements/test.txt
 pytest-django==4.1.0      # via -r requirements/test.txt
-pytest==6.1.2             # via -r requirements/test.txt, pytest-cov, pytest-django
+pytest==6.2.1             # via -r requirements/test.txt, pytest-cov, pytest-django
 python-slugify==4.0.1     # via -r requirements/test.txt, code-annotations
 pytz==2020.4              # via -r requirements/test.txt, babel, celery, django
 pyyaml==5.3.1             # via -r requirements/test.txt, code-annotations
 readme-renderer==28.0     # via -r requirements/doc.in, twine
 requests-toolbelt==0.9.1  # via twine
-requests==2.25.0          # via -r requirements/test.txt, requests-toolbelt, slumber, sphinx, twine
+requests==2.25.1          # via -r requirements/test.txt, requests-toolbelt, slumber, sphinx, twine
 restructuredtext-lint==1.3.2  # via doc8
 simplejson==3.17.2        # via -r requirements/test.txt, super-csv
-six==1.15.0               # via -r requirements/test.txt, bleach, doc8, edx-opaque-keys, edx-sphinx-theme, mock, pathlib2, readme-renderer, stevedore
+six==1.15.0               # via -r requirements/test.txt, bleach, doc8, edx-opaque-keys, edx-sphinx-theme, mock, readme-renderer, stevedore
 slumber==0.7.1            # via -r requirements/test.txt
 snowballstemmer==2.0.0    # via sphinx
-sphinx==3.3.1             # via -r requirements/doc.in, edx-sphinx-theme
+sphinx==3.4.0             # via -r requirements/doc.in, edx-sphinx-theme
 sphinxcontrib-applehelp==1.0.2  # via sphinx
 sphinxcontrib-devhelp==1.0.2  # via sphinx
 sphinxcontrib-htmlhelp==1.0.3  # via sphinx
@@ -72,15 +70,14 @@ sphinxcontrib-qthelp==1.0.3  # via sphinx
 sphinxcontrib-serializinghtml==1.1.4  # via sphinx
 sqlparse==0.4.1           # via -r requirements/test.txt, django
 stevedore==1.32.0         # via -c requirements/constraints.txt, -r requirements/test.txt, code-annotations, doc8, edx-django-utils, edx-opaque-keys
-super-csv==1.1.0          # via -r requirements/test.txt
+super-csv==2.0.0          # via -r requirements/test.txt
 text-unidecode==1.3       # via -r requirements/test.txt, python-slugify
 toml==0.10.2              # via -r requirements/test.txt, pytest
 tqdm==4.54.1              # via twine
 twine==1.15.0             # via -c requirements/constraints.txt, -r requirements/doc.in
 urllib3==1.26.2           # via -r requirements/test.txt, requests
-vine==1.3.0               # via -r requirements/test.txt, amqp
+vine==1.3.0               # via -r requirements/test.txt, amqp, celery
 webencodings==0.5.1       # via bleach
-zipp==1.2.0               # via -c requirements/constraints.txt, -r requirements/test.txt, importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/pii_check.in
+++ b/requirements/pii_check.in
@@ -1,0 +1,6 @@
+# Requirements for running pii_check
+-c constraints.txt
+
+-r base.txt               # Core dependencies for this package
+
+code-annotations          # provides commands used by the pii_check make target.

--- a/requirements/pii_check.txt
+++ b/requirements/pii_check.txt
@@ -4,48 +4,41 @@
 #
 #    make upgrade
 #
-attrs==20.3.0             # via pytest
+amqp==2.6.1               # via -r requirements/base.txt, kombu
+billiard==3.6.3.0         # via -r requirements/base.txt, celery
+celery==4.4.7             # via -c requirements/constraints.txt, -r requirements/base.txt, edx-celeryutils
 certifi==2020.12.5        # via -r requirements/base.txt, requests
 chardet==4.0.0            # via -r requirements/base.txt, requests
 click==7.1.2              # via code-annotations
-code-annotations==0.10.2  # via -r requirements/test.in
-coverage==5.3.1           # via pytest-cov
-ddt==1.4.1                # via -r requirements/test.in
+code-annotations==0.10.2  # via -r requirements/pii_check.in
 django-crum==0.7.9        # via -r requirements/base.txt, edx-django-utils, super-csv
 django-model-utils==4.1.1  # via -r requirements/base.txt, edx-celeryutils, super-csv
 django-waffle==2.0.0      # via -r requirements/base.txt, edx-django-utils
+django==2.2.17            # via -c requirements/constraints.txt, -r requirements/base.txt, code-annotations, django-crum, django-model-utils, djangorestframework, edx-celeryutils, edx-django-utils, jsonfield2, super-csv
 djangorestframework==3.12.2  # via -r requirements/base.txt, super-csv
 edx-celeryutils==0.5.2    # via -r requirements/base.txt, super-csv
 edx-django-utils==3.13.0  # via -r requirements/base.txt, super-csv
 edx-opaque-keys==2.1.1    # via -r requirements/base.txt
 future==0.18.2            # via -r requirements/base.txt, edx-celeryutils
 idna==2.10                # via -r requirements/base.txt, requests
-iniconfig==1.1.1          # via pytest
 jinja2==2.11.2            # via code-annotations
 jsonfield2==3.0.3         # via -c requirements/constraints.txt, -r requirements/base.txt, edx-celeryutils
+kombu==4.6.11             # via -r requirements/base.txt, celery
 markupsafe==1.1.1         # via jinja2
-mock==3.0.5               # via -c requirements/constraints.txt, -r requirements/test.in
 newrelic==5.24.0.153      # via -r requirements/base.txt, edx-django-utils
-packaging==20.8           # via pytest
 pbr==5.5.1                # via -r requirements/base.txt, stevedore
-pluggy==0.13.1            # via pytest
 psutil==5.8.0             # via -r requirements/base.txt, edx-django-utils
-py==1.10.0                # via pytest
 pymongo==3.11.2           # via -r requirements/base.txt, edx-opaque-keys
-pyparsing==2.4.7          # via packaging
-pytest-cov==2.10.1        # via -r requirements/test.in
-pytest-django==4.1.0      # via -r requirements/test.in
-pytest==6.2.1             # via pytest-cov, pytest-django
 python-slugify==4.0.1     # via code-annotations
 pytz==2020.4              # via -r requirements/base.txt, celery, django
 pyyaml==5.3.1             # via code-annotations
 requests==2.25.1          # via -r requirements/base.txt, slumber
 simplejson==3.17.2        # via -r requirements/base.txt, super-csv
-six==1.15.0               # via -r requirements/base.txt, edx-opaque-keys, mock, stevedore
+six==1.15.0               # via -r requirements/base.txt, edx-opaque-keys, stevedore
 slumber==0.7.1            # via -r requirements/base.txt
 sqlparse==0.4.1           # via -r requirements/base.txt, django
 stevedore==1.32.0         # via -c requirements/constraints.txt, -r requirements/base.txt, code-annotations, edx-django-utils, edx-opaque-keys
 super-csv==2.0.0          # via -r requirements/base.txt
 text-unidecode==1.3       # via python-slugify
-toml==0.10.2              # via pytest
 urllib3==1.26.2           # via -r requirements/base.txt, requests
+vine==1.3.0               # via -r requirements/base.txt, amqp, celery

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -5,16 +5,16 @@
 #    make upgrade
 #
 amqp==2.6.1               # via -r requirements/test.txt, kombu
-astroid==2.3.3            # via pylint, pylint-celery
+astroid==2.4.2            # via pylint, pylint-celery
 attrs==20.3.0             # via -r requirements/test.txt, pytest
-billiard==3.5.0.5         # via -r requirements/test.txt, celery
-celery==4.2.2             # via -c requirements/constraints.txt, -r requirements/test.txt, edx-celeryutils
+billiard==3.6.3.0         # via -r requirements/test.txt, celery
+celery==4.4.7             # via -c requirements/constraints.txt, -r requirements/test.txt, edx-celeryutils
 certifi==2020.12.5        # via -r requirements/test.txt, requests
-chardet==3.0.4            # via -r requirements/test.txt, requests
+chardet==4.0.0            # via -r requirements/test.txt, requests
 click-log==0.3.2          # via edx-lint
 click==7.1.2              # via -r requirements/test.txt, click-log, code-annotations, edx-lint
 code-annotations==0.10.2  # via -r requirements/test.txt
-coverage==5.3             # via -r requirements/test.txt, pytest-cov
+coverage==5.3.1           # via -r requirements/test.txt, pytest-cov
 ddt==1.4.1                # via -r requirements/test.txt
 django-crum==0.7.9        # via -r requirements/test.txt, edx-django-utils, super-csv
 django-model-utils==4.1.1  # via -r requirements/test.txt, edx-celeryutils, super-csv
@@ -23,53 +23,49 @@ django==2.2.17            # via -c requirements/constraints.txt, -r requirements
 djangorestframework==3.12.2  # via -r requirements/test.txt, super-csv
 edx-celeryutils==0.5.2    # via -r requirements/test.txt, super-csv
 edx-django-utils==3.13.0  # via -r requirements/test.txt, super-csv
-edx-lint==1.5.2           # via -r requirements/quality.in
+edx-lint==1.6             # via -r requirements/quality.in
 edx-opaque-keys==2.1.1    # via -r requirements/test.txt
 future==0.18.2            # via -r requirements/test.txt, edx-celeryutils
 idna==2.10                # via -r requirements/test.txt, requests
-importlib-metadata==2.1.1  # via -r requirements/test.txt, pluggy, pytest
 iniconfig==1.1.1          # via -r requirements/test.txt, pytest
-isort==4.3.21             # via -r requirements/quality.in, pylint
+isort==5.6.4              # via -r requirements/quality.in, pylint
 jinja2==2.11.2            # via -r requirements/test.txt, code-annotations
 jsonfield2==3.0.3         # via -c requirements/constraints.txt, -r requirements/test.txt, edx-celeryutils
-kombu==4.3.0              # via -r requirements/test.txt, celery
+kombu==4.6.11             # via -r requirements/test.txt, celery
 lazy-object-proxy==1.4.3  # via astroid
 markupsafe==1.1.1         # via -r requirements/test.txt, jinja2
 mccabe==0.6.1             # via pylint
 mock==3.0.5               # via -c requirements/constraints.txt, -r requirements/test.txt
-newrelic==5.22.1.152      # via -r requirements/test.txt, edx-django-utils
-packaging==20.7           # via -r requirements/test.txt, pytest
-pathlib2==2.3.5           # via -r requirements/test.txt, pytest
+newrelic==5.24.0.153      # via -r requirements/test.txt, edx-django-utils
+packaging==20.8           # via -r requirements/test.txt, pytest
 pbr==5.5.1                # via -r requirements/test.txt, stevedore
 pluggy==0.13.1            # via -r requirements/test.txt, pytest
-psutil==5.7.3             # via -r requirements/test.txt, edx-django-utils
-py==1.9.0                 # via -r requirements/test.txt, pytest
+psutil==5.8.0             # via -r requirements/test.txt, edx-django-utils
+py==1.10.0                # via -r requirements/test.txt, pytest
 pycodestyle==2.6.0        # via -r requirements/quality.in
 pydocstyle==5.1.1         # via -r requirements/quality.in
 pylint-celery==0.3        # via edx-lint
-pylint-django==2.0.11     # via edx-lint
+pylint-django==2.3.0      # via edx-lint
 pylint-plugin-utils==0.6  # via pylint-celery, pylint-django
-pylint==2.4.4             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
+pylint==2.6.0             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
 pymongo==3.11.2           # via -r requirements/test.txt, edx-opaque-keys
 pyparsing==2.4.7          # via -r requirements/test.txt, packaging
 pytest-cov==2.10.1        # via -r requirements/test.txt
 pytest-django==4.1.0      # via -r requirements/test.txt
-pytest==6.1.2             # via -r requirements/test.txt, pytest-cov, pytest-django
+pytest==6.2.1             # via -r requirements/test.txt, pytest-cov, pytest-django
 python-slugify==4.0.1     # via -r requirements/test.txt, code-annotations
 pytz==2020.4              # via -r requirements/test.txt, celery, django
 pyyaml==5.3.1             # via -r requirements/test.txt, code-annotations
-requests==2.25.0          # via -r requirements/test.txt, slumber
+requests==2.25.1          # via -r requirements/test.txt, slumber
 simplejson==3.17.2        # via -r requirements/test.txt, super-csv
-six==1.15.0               # via -r requirements/test.txt, astroid, edx-lint, edx-opaque-keys, mock, pathlib2, stevedore
+six==1.15.0               # via -r requirements/test.txt, astroid, edx-lint, edx-opaque-keys, mock, stevedore
 slumber==0.7.1            # via -r requirements/test.txt
 snowballstemmer==2.0.0    # via pydocstyle
 sqlparse==0.4.1           # via -r requirements/test.txt, django
 stevedore==1.32.0         # via -c requirements/constraints.txt, -r requirements/test.txt, code-annotations, edx-django-utils, edx-opaque-keys
-super-csv==1.1.0          # via -r requirements/test.txt
+super-csv==2.0.0          # via -r requirements/test.txt
 text-unidecode==1.3       # via -r requirements/test.txt, python-slugify
-toml==0.10.2              # via -r requirements/test.txt, pytest
-typed-ast==1.4.1          # via astroid
+toml==0.10.2              # via -r requirements/test.txt, pylint, pytest
 urllib3==1.26.2           # via -r requirements/test.txt, requests
-vine==1.3.0               # via -r requirements/test.txt, amqp
-wrapt==1.11.2             # via astroid
-zipp==1.2.0               # via -c requirements/constraints.txt, -r requirements/test.txt, importlib-metadata
+vine==1.3.0               # via -r requirements/test.txt, amqp, celery
+wrapt==1.12.1             # via astroid

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -6,23 +6,20 @@
 #
 appdirs==1.4.4            # via virtualenv
 certifi==2020.12.5        # via requests
-chardet==3.0.4            # via requests
-codecov==2.1.10           # via -r requirements/travis.in
-coverage==5.3             # via codecov
+chardet==4.0.0            # via requests
+codecov==2.1.11           # via -r requirements/travis.in
+coverage==5.3.1           # via codecov
 distlib==0.3.1            # via virtualenv
 filelock==3.0.12          # via tox, virtualenv
 idna==2.10                # via requests
-importlib-metadata==2.1.1  # via pluggy, tox, virtualenv
-importlib-resources==3.2.1  # via virtualenv
-packaging==20.7           # via tox
+packaging==20.8           # via tox
 pluggy==0.13.1            # via tox
-py==1.9.0                 # via tox
+py==1.10.0                # via tox
 pyparsing==2.4.7          # via packaging
-requests==2.25.0          # via codecov
+requests==2.25.1          # via codecov
 six==1.15.0               # via tox, virtualenv
 toml==0.10.2              # via tox
 tox-battery==0.6.1        # via -r requirements/travis.in
 tox==3.20.1               # via -r requirements/travis.in, tox-battery
 urllib3==1.26.2           # via requests
 virtualenv==20.2.2        # via tox
-zipp==1.2.0               # via -c requirements/constraints.txt, importlib-metadata, importlib-resources

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -10,16 +10,16 @@ from copy import deepcopy
 from itertools import chain, cycle, repeat
 
 import ddt
+import lms.djangoapps.grades.api as grades_api
 from django.contrib.auth.models import User
 from django.core.files.base import ContentFile
 from django.test import TestCase
 from mock import MagicMock, Mock, patch
 from opaque_keys.edx.keys import UsageKey
+from student.models import CourseEnrollment, Profile, ProgramCourseEnrollment
 from super_csv.csv_processor import ValidationError
 
-import lms.djangoapps.grades.api as grades_api
 from bulk_grades import api
-from student.models import CourseEnrollment, Profile, ProgramCourseEnrollment
 
 
 class BaseTests(TestCase):
@@ -28,7 +28,7 @@ class BaseTests(TestCase):
     """
     @classmethod
     def setUpTestData(cls):
-        super(BaseTests, cls).setUpTestData()
+        super().setUpTestData()
         cls.learner = User.objects.create(username='student@example.com')
         cls.staff = User.objects.create(username='staff@example.com')
         cls.usage_key = 'block-v1:testX+sg101+2019+type@sequential+block@homework_questions'
@@ -195,7 +195,7 @@ class TestGradedSubsectionMixin(BaseTests):
     Tests the shared methods defined in ``GradeSubsectionMixin``.
     """
     def setUp(self):
-        super(TestGradedSubsectionMixin, self).setUp()
+        super().setUp()
         self.instance = MySubsectionClass()
 
     @patch('lms.djangoapps.grades.api.graded_subsections_for_course_id')
@@ -496,7 +496,7 @@ class TestInterventionProcessor(BaseTests):
 
     @classmethod
     def setUpClass(cls):
-        super(TestInterventionProcessor, cls).setUpClass()
+        super().setUpClass()
         cls.grade_factory_patcher = patch('lms.djangoapps.grades.api.CourseGradeFactory.read')
         cls.learner_api_client_patcher = patch('bulk_grades.api.LearnerAPIClient')
         cls.mocked_learner_api_client = cls.learner_api_client_patcher.start()
@@ -524,17 +524,17 @@ class TestInterventionProcessor(BaseTests):
 
     @classmethod
     def tearDownClass(cls):
-        super(TestInterventionProcessor, cls).tearDownClass()
+        super().tearDownClass()
         cls.learner_api_client_patcher.stop()
 
     def setUp(self):
-        super(TestInterventionProcessor, self).setUp()
+        super().setUp()
         self.mocked_course_grade_factory = self.grade_factory_patcher.start()
         course_grade_mock = Mock(percent=0.5, letter_grade='A')
         self.mocked_course_grade_factory.return_value = course_grade_mock
 
     def tearDown(self):
-        super(TestInterventionProcessor, self).tearDown()
+        super().tearDown()
         self.grade_factory_patcher.stop()
 
     def test_export(self):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -4,11 +4,11 @@
 Tests for the `edx-bulk-grades` models module.
 """
 
+from courseware.models import StudentModule
 from django.contrib.auth.models import User
 from django.test import TestCase
 
 from bulk_grades.models import ScoreOverrider
-from courseware.models import StudentModule
 
 
 class TestScoreOverrider(TestCase):

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,13 +1,13 @@
 """ Tests for bulk grade views """
+import lms.djangoapps.grades.api as grades_api
 from django.contrib.auth.models import User
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import TestCase
 from django.urls import reverse
 from mock import Mock, patch
-
-import lms.djangoapps.grades.api as grades_api
-from bulk_grades.api import GradeCSVProcessor
 from student.models import CourseEnrollment, Profile, ProgramCourseEnrollment
+
+from bulk_grades.api import GradeCSVProcessor
 
 
 class ViewTestsMixin(object):
@@ -15,7 +15,7 @@ class ViewTestsMixin(object):
 
     @classmethod
     def setUpTestData(cls):
-        super(ViewTestsMixin, cls).setUpTestData()
+        super().setUpTestData()
         cls.password = 'password'
         cls.staff = User.objects.create(username='staff@example.com', password=cls.password)
         cls.course_id = 'course-v1:testX+sg101+2019'
@@ -107,7 +107,7 @@ class InterventionsExportViewTests(ViewTestsMixin, TestCase):
 
     @classmethod
     def setUpTestData(cls):
-        super(InterventionsExportViewTests, cls).setUpTestData()
+        super().setUpTestData()
         cls.masters_learner_2 = cls._make_enrollment('masters2', 'masters')
         cls.learner_api_client_patcher = patch('bulk_grades.api.LearnerAPIClient')
         cls.mocked_learner_api_client = cls.learner_api_client_patcher.start()

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py(35,38}-django{22}
+envlist = py38-django{22}-celery{44,50}
 
 [testenv]
 setenv =
@@ -7,6 +7,8 @@ setenv =
 deps =
     -r{toxinidir}/requirements/test.txt
     django22: Django>=2.2,<2.3
+    celery44: -r{toxinidir}/requirements/celery44.txt
+    celery50: -r{toxinidir}/requirements/celery50.txt
 commands =
     python -Wd -m pytest {posargs}
 
@@ -29,6 +31,9 @@ commands =
     twine check dist/*
 
 [testenv:quality]
+setenv =
+    DJANGO_SETTINGS_MODULE = test_settings
+    PYTHONPATH = {toxinidir}/mock_apps/
 whitelist_externals =
     make
     rm
@@ -48,6 +53,6 @@ setenv =
     DJANGO_SETTINGS_MODULE = test_settings
     PYTHONPATH = {toxinidir}/mock_apps/
 deps =
-    -r{toxinidir}/requirements/test.txt
+    -r{toxinidir}/requirements/pii_check.txt
 commands =
     code_annotations django_find_annotations --config_file .pii_annotations.yml --lint --report --coverage


### PR DESCRIPTION
**Description:** As we are planning to upgrade platform to latest version of `celery`, so we are going to add testing for the latest version of celery first.

- Added celery 5 support
- Moved `pii_check` requirements to new files as it was causing issues in testing multiple versions of celery
- Ran make upgrade
- Fixed quality

**JIRA:** https://openedx.atlassian.net/browse/BOM-2170

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)
