### PR TITLE
Upgrade celery to 5.0.4

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,11 @@ Unreleased
 ~~~~~~~~~~
 *
 
+[0.8.5] - 2020-12-24
+~~~~~~~~~~~~~~~~~~~~~
+* Upgrading celery to 5.0
+* Removed python 3.5 classifier as its support is dropped earlier
+
 [0.8.4] - 2020-12-24
 ~~~~~~~~~~~~~~~~~~~~~
 * Adding celery5.0 testing using tox.

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ upgrade: ## update the requirements/*.txt files with the latest packages satisfy
 	# Let tox control the Django,celery versions for tests
 	sed '/^[dD]jango==/d' requirements/test.txt > requirements/test.tmp
 	mv requirements/test.tmp requirements/test.txt
-	grep -e "^amqp==\|^anyjson==\|^billiard==\|^celery==\|^kombu==\|^click-didyoumean==\|^click-repl==\|^click==\|^prompt-toolkit==\|^vine==" requirements/base.txt > requirements/celery44.txt
+	grep -e "^amqp==\|^anyjson==\|^billiard==\|^celery==\|^kombu==\|^click-didyoumean==\|^click-repl==\|^click==\|^prompt-toolkit==\|^vine==" requirements/base.txt > requirements/celery50.txt
 	sed -i.tmp '/^amqp==/d' requirements/test.txt
 	sed -i.tmp '/^anyjson==/d' requirements/test.txt
 	sed -i.tmp '/^billiard==/d' requirements/test.txt

--- a/bulk_grades/__init__.py
+++ b/bulk_grades/__init__.py
@@ -2,6 +2,6 @@
 Support for bulk scoring and grading.
 """
 
-__version__ = '0.8.4'
+__version__ = '0.8.5'
 
 default_app_config = 'bulk_grades.apps.BulkGradesConfig'  # pylint: disable=invalid-name

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,11 +4,15 @@
 #
 #    make upgrade
 #
-amqp==2.6.1               # via kombu
+amqp==5.0.2               # via kombu
 billiard==3.6.3.0         # via celery
-celery==4.4.7             # via -c requirements/constraints.txt, edx-celeryutils
+celery==5.0.5             # via -c requirements/constraints.txt, edx-celeryutils
 certifi==2020.12.5        # via requests
 chardet==4.0.0            # via requests
+click-didyoumean==0.0.3   # via celery
+click-plugins==1.1.1      # via celery
+click-repl==0.1.6         # via celery
+click==7.1.2              # via celery, click-didyoumean, click-plugins, click-repl
 django-crum==0.7.9        # via edx-django-utils, super-csv
 django-model-utils==4.1.1  # via -r requirements/base.in, edx-celeryutils, super-csv
 django-waffle==2.0.0      # via edx-django-utils
@@ -20,18 +24,20 @@ edx-opaque-keys==2.1.1    # via -r requirements/base.in
 future==0.18.2            # via edx-celeryutils
 idna==2.10                # via requests
 jsonfield2==3.0.3         # via -c requirements/constraints.txt, edx-celeryutils
-kombu==4.6.11             # via celery
+kombu==5.0.2              # via celery
 newrelic==5.24.0.153      # via edx-django-utils
 pbr==5.5.1                # via stevedore
+prompt-toolkit==3.0.9     # via click-repl
 psutil==5.8.0             # via edx-django-utils
 pymongo==3.11.2           # via edx-opaque-keys
-pytz==2020.4              # via celery, django
+pytz==2020.5              # via celery, django
 requests==2.25.1          # via -r requirements/base.in, slumber
 simplejson==3.17.2        # via super-csv
-six==1.15.0               # via -r requirements/base.in, edx-opaque-keys, stevedore
+six==1.15.0               # via -r requirements/base.in, click-repl, edx-opaque-keys, stevedore
 slumber==0.7.1            # via -r requirements/base.in
 sqlparse==0.4.1           # via django
 stevedore==1.32.0         # via -c requirements/constraints.txt, edx-django-utils, edx-opaque-keys
 super-csv==2.0.0          # via -r requirements/base.in
 urllib3==1.26.2           # via requests
-vine==1.3.0               # via amqp, celery
+vine==5.0.0               # via amqp, celery
+wcwidth==0.2.5            # via prompt-toolkit

--- a/requirements/celery50.txt
+++ b/requirements/celery50.txt
@@ -1,9 +1,9 @@
 amqp==5.0.2               # via kombu
 billiard==3.6.3.0         # via celery
-celery==5.0.5             # via edx-celeryutils
+celery==5.0.5             # via -c requirements/constraints.txt, edx-celeryutils
 click-didyoumean==0.0.3   # via celery
 click-repl==0.1.6         # via celery
 click==7.1.2              # via celery, click-didyoumean, click-plugins, click-repl
 kombu==5.0.2              # via celery
-prompt-toolkit==3.0.8     # via click-repl
+prompt-toolkit==3.0.9     # via click-repl
 vine==5.0.0               # via amqp, celery

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -27,5 +27,5 @@ twine<2.0
 # greater versions drops support for python 3.5
 stevedore<2.0
 
-# Keeping celery 4.4.7 in the production currently
-celery<5.0
+# pinning celery to latest release
+celery<6.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,21 +4,24 @@
 #
 #    make upgrade
 #
-amqp==2.6.1               # via -r requirements/quality.txt, kombu
+amqp==5.0.2               # via -r requirements/quality.txt, kombu
 appdirs==1.4.4            # via -r requirements/travis.txt, virtualenv
 astroid==2.4.2            # via -r requirements/quality.txt, pylint, pylint-celery
 attrs==20.3.0             # via -r requirements/quality.txt, pytest
 billiard==3.6.3.0         # via -r requirements/quality.txt, celery
-celery==4.4.7             # via -c requirements/constraints.txt, -r requirements/quality.txt, edx-celeryutils
+celery==5.0.5             # via -c requirements/constraints.txt, -r requirements/quality.txt, edx-celeryutils
 certifi==2020.12.5        # via -r requirements/quality.txt, -r requirements/travis.txt, requests
 chardet==4.0.0            # via -r requirements/quality.txt, -r requirements/travis.txt, requests
+click-didyoumean==0.0.3   # via -r requirements/quality.txt, celery
 click-log==0.3.2          # via -r requirements/quality.txt, edx-lint
-click==7.1.2              # via -r requirements/pip-tools.txt, -r requirements/quality.txt, click-log, code-annotations, edx-lint, pip-tools
+click-plugins==1.1.1      # via -r requirements/quality.txt, celery
+click-repl==0.1.6         # via -r requirements/quality.txt, celery
+click==7.1.2              # via -r requirements/pip-tools.txt, -r requirements/quality.txt, celery, click-didyoumean, click-log, click-plugins, click-repl, code-annotations, edx-lint, pip-tools
 code-annotations==0.10.2  # via -r requirements/quality.txt
 codecov==2.1.11           # via -r requirements/travis.txt
 coverage==5.3.1           # via -r requirements/quality.txt, -r requirements/travis.txt, codecov, pytest-cov
 ddt==1.4.1                # via -r requirements/quality.txt
-diff-cover==4.0.1         # via -r requirements/dev.in
+diff-cover==4.1.0         # via -r requirements/dev.in
 distlib==0.3.1            # via -r requirements/travis.txt, virtualenv
 django-crum==0.7.9        # via -r requirements/quality.txt, edx-django-utils, super-csv
 django-model-utils==4.1.1  # via -r requirements/quality.txt, edx-celeryutils, super-csv
@@ -35,11 +38,11 @@ future==0.18.2            # via -r requirements/quality.txt, edx-celeryutils
 idna==2.10                # via -r requirements/quality.txt, -r requirements/travis.txt, requests
 inflect==5.0.2            # via jinja2-pluralize
 iniconfig==1.1.1          # via -r requirements/quality.txt, pytest
-isort==5.6.4              # via -r requirements/quality.txt, pylint
+isort==5.7.0              # via -r requirements/quality.txt, pylint
 jinja2-pluralize==0.3.0   # via diff-cover
 jinja2==2.11.2            # via -r requirements/quality.txt, code-annotations, diff-cover, jinja2-pluralize
 jsonfield2==3.0.3         # via -c requirements/constraints.txt, -r requirements/quality.txt, edx-celeryutils
-kombu==4.6.11             # via -r requirements/quality.txt, celery
+kombu==5.0.2              # via -r requirements/quality.txt, celery
 lazy-object-proxy==1.4.3  # via -r requirements/quality.txt, astroid
 markupsafe==1.1.1         # via -r requirements/quality.txt, jinja2
 mccabe==0.6.1             # via -r requirements/quality.txt, pylint
@@ -49,9 +52,10 @@ packaging==20.8           # via -r requirements/quality.txt, -r requirements/tra
 path.py==12.5.0           # via edx-i18n-tools
 path==15.0.1              # via path.py
 pbr==5.5.1                # via -r requirements/quality.txt, stevedore
-pip-tools==5.4.0          # via -r requirements/pip-tools.txt
+pip-tools==5.5.0          # via -r requirements/pip-tools.txt
 pluggy==0.13.1            # via -r requirements/quality.txt, -r requirements/travis.txt, diff-cover, pytest, tox
 polib==1.1.0              # via edx-i18n-tools
+prompt-toolkit==3.0.9     # via -r requirements/quality.txt, click-repl
 psutil==5.8.0             # via -r requirements/quality.txt, edx-django-utils
 py==1.10.0                # via -r requirements/quality.txt, -r requirements/travis.txt, pytest, tox
 pycodestyle==2.6.0        # via -r requirements/quality.txt
@@ -67,11 +71,11 @@ pytest-cov==2.10.1        # via -r requirements/quality.txt
 pytest-django==4.1.0      # via -r requirements/quality.txt
 pytest==6.2.1             # via -r requirements/quality.txt, pytest-cov, pytest-django
 python-slugify==4.0.1     # via -r requirements/quality.txt, code-annotations
-pytz==2020.4              # via -r requirements/quality.txt, celery, django
+pytz==2020.5              # via -r requirements/quality.txt, celery, django
 pyyaml==5.3.1             # via -r requirements/quality.txt, code-annotations, edx-i18n-tools
 requests==2.25.1          # via -r requirements/quality.txt, -r requirements/travis.txt, codecov, slumber
 simplejson==3.17.2        # via -r requirements/quality.txt, super-csv
-six==1.15.0               # via -r requirements/pip-tools.txt, -r requirements/quality.txt, -r requirements/travis.txt, astroid, edx-i18n-tools, edx-lint, edx-opaque-keys, mock, pip-tools, stevedore, tox, virtualenv
+six==1.15.0               # via -r requirements/quality.txt, -r requirements/travis.txt, astroid, click-repl, edx-i18n-tools, edx-lint, edx-opaque-keys, mock, stevedore, tox, virtualenv
 slumber==0.7.1            # via -r requirements/quality.txt
 snowballstemmer==2.0.0    # via -r requirements/quality.txt, pydocstyle
 sqlparse==0.4.1           # via -r requirements/quality.txt, django
@@ -82,8 +86,9 @@ toml==0.10.2              # via -r requirements/quality.txt, -r requirements/tra
 tox-battery==0.6.1        # via -r requirements/travis.txt
 tox==3.20.1               # via -r requirements/travis.txt, tox-battery
 urllib3==1.26.2           # via -r requirements/quality.txt, -r requirements/travis.txt, requests
-vine==1.3.0               # via -r requirements/quality.txt, amqp, celery
+vine==5.0.0               # via -r requirements/quality.txt, amqp, celery
 virtualenv==20.2.2        # via -r requirements/travis.txt, tox
+wcwidth==0.2.5            # via -r requirements/quality.txt, prompt-toolkit
 wrapt==1.12.1             # via -r requirements/quality.txt, astroid
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -5,15 +5,18 @@
 #    make upgrade
 #
 alabaster==0.7.12         # via sphinx
-amqp==2.6.1               # via -r requirements/test.txt, kombu
+amqp==5.0.2               # via -r requirements/test.txt, kombu
 attrs==20.3.0             # via -r requirements/test.txt, pytest
 babel==2.9.0              # via sphinx
 billiard==3.6.3.0         # via -r requirements/test.txt, celery
 bleach==3.2.1             # via readme-renderer
-celery==4.4.7             # via -c requirements/constraints.txt, -r requirements/test.txt, edx-celeryutils
+celery==5.0.5             # via -c requirements/constraints.txt, -r requirements/test.txt, edx-celeryutils
 certifi==2020.12.5        # via -r requirements/test.txt, requests
 chardet==4.0.0            # via -r requirements/test.txt, doc8, requests
-click==7.1.2              # via -r requirements/test.txt, code-annotations
+click-didyoumean==0.0.3   # via -r requirements/test.txt, celery
+click-plugins==1.1.1      # via -r requirements/test.txt, celery
+click-repl==0.1.6         # via -r requirements/test.txt, celery
+click==7.1.2              # via -r requirements/test.txt, celery, click-didyoumean, click-plugins, click-repl, code-annotations
 code-annotations==0.10.2  # via -r requirements/test.txt
 coverage==5.3.1           # via -r requirements/test.txt, pytest-cov
 ddt==1.4.1                # via -r requirements/test.txt
@@ -34,7 +37,7 @@ imagesize==1.2.0          # via sphinx
 iniconfig==1.1.1          # via -r requirements/test.txt, pytest
 jinja2==2.11.2            # via -r requirements/test.txt, code-annotations, sphinx
 jsonfield2==3.0.3         # via -c requirements/constraints.txt, -r requirements/test.txt, edx-celeryutils
-kombu==4.6.11             # via -r requirements/test.txt, celery
+kombu==5.0.2              # via -r requirements/test.txt, celery
 markupsafe==1.1.1         # via -r requirements/test.txt, jinja2
 mock==3.0.5               # via -c requirements/constraints.txt, -r requirements/test.txt
 newrelic==5.24.0.153      # via -r requirements/test.txt, edx-django-utils
@@ -42,6 +45,7 @@ packaging==20.8           # via -r requirements/test.txt, bleach, pytest, sphinx
 pbr==5.5.1                # via -r requirements/test.txt, stevedore
 pkginfo==1.6.1            # via twine
 pluggy==0.13.1            # via -r requirements/test.txt, pytest
+prompt-toolkit==3.0.9     # via -r requirements/test.txt, click-repl
 psutil==5.8.0             # via -r requirements/test.txt, edx-django-utils
 py==1.10.0                # via -r requirements/test.txt, pytest
 pygments==2.7.3           # via doc8, readme-renderer, sphinx
@@ -51,17 +55,17 @@ pytest-cov==2.10.1        # via -r requirements/test.txt
 pytest-django==4.1.0      # via -r requirements/test.txt
 pytest==6.2.1             # via -r requirements/test.txt, pytest-cov, pytest-django
 python-slugify==4.0.1     # via -r requirements/test.txt, code-annotations
-pytz==2020.4              # via -r requirements/test.txt, babel, celery, django
+pytz==2020.5              # via -r requirements/test.txt, babel, celery, django
 pyyaml==5.3.1             # via -r requirements/test.txt, code-annotations
 readme-renderer==28.0     # via -r requirements/doc.in, twine
 requests-toolbelt==0.9.1  # via twine
 requests==2.25.1          # via -r requirements/test.txt, requests-toolbelt, slumber, sphinx, twine
 restructuredtext-lint==1.3.2  # via doc8
 simplejson==3.17.2        # via -r requirements/test.txt, super-csv
-six==1.15.0               # via -r requirements/test.txt, bleach, doc8, edx-opaque-keys, edx-sphinx-theme, mock, readme-renderer, stevedore
+six==1.15.0               # via -r requirements/test.txt, bleach, click-repl, doc8, edx-opaque-keys, edx-sphinx-theme, mock, readme-renderer, stevedore
 slumber==0.7.1            # via -r requirements/test.txt
 snowballstemmer==2.0.0    # via sphinx
-sphinx==3.4.0             # via -r requirements/doc.in, edx-sphinx-theme
+sphinx==3.4.3             # via -r requirements/doc.in, edx-sphinx-theme
 sphinxcontrib-applehelp==1.0.2  # via sphinx
 sphinxcontrib-devhelp==1.0.2  # via sphinx
 sphinxcontrib-htmlhelp==1.0.3  # via sphinx
@@ -73,10 +77,11 @@ stevedore==1.32.0         # via -c requirements/constraints.txt, -r requirements
 super-csv==2.0.0          # via -r requirements/test.txt
 text-unidecode==1.3       # via -r requirements/test.txt, python-slugify
 toml==0.10.2              # via -r requirements/test.txt, pytest
-tqdm==4.54.1              # via twine
+tqdm==4.55.1              # via twine
 twine==1.15.0             # via -c requirements/constraints.txt, -r requirements/doc.in
 urllib3==1.26.2           # via -r requirements/test.txt, requests
-vine==1.3.0               # via -r requirements/test.txt, amqp, celery
+vine==5.0.0               # via -r requirements/test.txt, amqp, celery
+wcwidth==0.2.5            # via -r requirements/test.txt, prompt-toolkit
 webencodings==0.5.1       # via bleach
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/pii_check.txt
+++ b/requirements/pii_check.txt
@@ -4,12 +4,15 @@
 #
 #    make upgrade
 #
-amqp==2.6.1               # via -r requirements/base.txt, kombu
+amqp==5.0.2               # via -r requirements/base.txt, kombu
 billiard==3.6.3.0         # via -r requirements/base.txt, celery
-celery==4.4.7             # via -c requirements/constraints.txt, -r requirements/base.txt, edx-celeryutils
+celery==5.0.5             # via -c requirements/constraints.txt, -r requirements/base.txt, edx-celeryutils
 certifi==2020.12.5        # via -r requirements/base.txt, requests
 chardet==4.0.0            # via -r requirements/base.txt, requests
-click==7.1.2              # via code-annotations
+click-didyoumean==0.0.3   # via -r requirements/base.txt, celery
+click-plugins==1.1.1      # via -r requirements/base.txt, celery
+click-repl==0.1.6         # via -r requirements/base.txt, celery
+click==7.1.2              # via -r requirements/base.txt, celery, click-didyoumean, click-plugins, click-repl, code-annotations
 code-annotations==0.10.2  # via -r requirements/pii_check.in
 django-crum==0.7.9        # via -r requirements/base.txt, edx-django-utils, super-csv
 django-model-utils==4.1.1  # via -r requirements/base.txt, edx-celeryutils, super-csv
@@ -23,22 +26,24 @@ future==0.18.2            # via -r requirements/base.txt, edx-celeryutils
 idna==2.10                # via -r requirements/base.txt, requests
 jinja2==2.11.2            # via code-annotations
 jsonfield2==3.0.3         # via -c requirements/constraints.txt, -r requirements/base.txt, edx-celeryutils
-kombu==4.6.11             # via -r requirements/base.txt, celery
+kombu==5.0.2              # via -r requirements/base.txt, celery
 markupsafe==1.1.1         # via jinja2
 newrelic==5.24.0.153      # via -r requirements/base.txt, edx-django-utils
 pbr==5.5.1                # via -r requirements/base.txt, stevedore
+prompt-toolkit==3.0.9     # via -r requirements/base.txt, click-repl
 psutil==5.8.0             # via -r requirements/base.txt, edx-django-utils
 pymongo==3.11.2           # via -r requirements/base.txt, edx-opaque-keys
 python-slugify==4.0.1     # via code-annotations
-pytz==2020.4              # via -r requirements/base.txt, celery, django
+pytz==2020.5              # via -r requirements/base.txt, celery, django
 pyyaml==5.3.1             # via code-annotations
 requests==2.25.1          # via -r requirements/base.txt, slumber
 simplejson==3.17.2        # via -r requirements/base.txt, super-csv
-six==1.15.0               # via -r requirements/base.txt, edx-opaque-keys, stevedore
+six==1.15.0               # via -r requirements/base.txt, click-repl, edx-opaque-keys, stevedore
 slumber==0.7.1            # via -r requirements/base.txt
 sqlparse==0.4.1           # via -r requirements/base.txt, django
 stevedore==1.32.0         # via -c requirements/constraints.txt, -r requirements/base.txt, code-annotations, edx-django-utils, edx-opaque-keys
 super-csv==2.0.0          # via -r requirements/base.txt
 text-unidecode==1.3       # via python-slugify
 urllib3==1.26.2           # via -r requirements/base.txt, requests
-vine==1.3.0               # via -r requirements/base.txt, amqp, celery
+vine==5.0.0               # via -r requirements/base.txt, amqp, celery
+wcwidth==0.2.5            # via -r requirements/base.txt, prompt-toolkit

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -5,8 +5,7 @@
 #    make upgrade
 #
 click==7.1.2              # via pip-tools
-pip-tools==5.4.0          # via -r requirements/pip-tools.in
-six==1.15.0               # via pip-tools
+pip-tools==5.5.0          # via -r requirements/pip-tools.in
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -4,15 +4,18 @@
 #
 #    make upgrade
 #
-amqp==2.6.1               # via -r requirements/test.txt, kombu
+amqp==5.0.2               # via -r requirements/test.txt, kombu
 astroid==2.4.2            # via pylint, pylint-celery
 attrs==20.3.0             # via -r requirements/test.txt, pytest
 billiard==3.6.3.0         # via -r requirements/test.txt, celery
-celery==4.4.7             # via -c requirements/constraints.txt, -r requirements/test.txt, edx-celeryutils
+celery==5.0.5             # via -c requirements/constraints.txt, -r requirements/test.txt, edx-celeryutils
 certifi==2020.12.5        # via -r requirements/test.txt, requests
 chardet==4.0.0            # via -r requirements/test.txt, requests
+click-didyoumean==0.0.3   # via -r requirements/test.txt, celery
 click-log==0.3.2          # via edx-lint
-click==7.1.2              # via -r requirements/test.txt, click-log, code-annotations, edx-lint
+click-plugins==1.1.1      # via -r requirements/test.txt, celery
+click-repl==0.1.6         # via -r requirements/test.txt, celery
+click==7.1.2              # via -r requirements/test.txt, celery, click-didyoumean, click-log, click-plugins, click-repl, code-annotations, edx-lint
 code-annotations==0.10.2  # via -r requirements/test.txt
 coverage==5.3.1           # via -r requirements/test.txt, pytest-cov
 ddt==1.4.1                # via -r requirements/test.txt
@@ -28,10 +31,10 @@ edx-opaque-keys==2.1.1    # via -r requirements/test.txt
 future==0.18.2            # via -r requirements/test.txt, edx-celeryutils
 idna==2.10                # via -r requirements/test.txt, requests
 iniconfig==1.1.1          # via -r requirements/test.txt, pytest
-isort==5.6.4              # via -r requirements/quality.in, pylint
+isort==5.7.0              # via -r requirements/quality.in, pylint
 jinja2==2.11.2            # via -r requirements/test.txt, code-annotations
 jsonfield2==3.0.3         # via -c requirements/constraints.txt, -r requirements/test.txt, edx-celeryutils
-kombu==4.6.11             # via -r requirements/test.txt, celery
+kombu==5.0.2              # via -r requirements/test.txt, celery
 lazy-object-proxy==1.4.3  # via astroid
 markupsafe==1.1.1         # via -r requirements/test.txt, jinja2
 mccabe==0.6.1             # via pylint
@@ -40,6 +43,7 @@ newrelic==5.24.0.153      # via -r requirements/test.txt, edx-django-utils
 packaging==20.8           # via -r requirements/test.txt, pytest
 pbr==5.5.1                # via -r requirements/test.txt, stevedore
 pluggy==0.13.1            # via -r requirements/test.txt, pytest
+prompt-toolkit==3.0.9     # via -r requirements/test.txt, click-repl
 psutil==5.8.0             # via -r requirements/test.txt, edx-django-utils
 py==1.10.0                # via -r requirements/test.txt, pytest
 pycodestyle==2.6.0        # via -r requirements/quality.in
@@ -54,11 +58,11 @@ pytest-cov==2.10.1        # via -r requirements/test.txt
 pytest-django==4.1.0      # via -r requirements/test.txt
 pytest==6.2.1             # via -r requirements/test.txt, pytest-cov, pytest-django
 python-slugify==4.0.1     # via -r requirements/test.txt, code-annotations
-pytz==2020.4              # via -r requirements/test.txt, celery, django
+pytz==2020.5              # via -r requirements/test.txt, celery, django
 pyyaml==5.3.1             # via -r requirements/test.txt, code-annotations
 requests==2.25.1          # via -r requirements/test.txt, slumber
 simplejson==3.17.2        # via -r requirements/test.txt, super-csv
-six==1.15.0               # via -r requirements/test.txt, astroid, edx-lint, edx-opaque-keys, mock, stevedore
+six==1.15.0               # via -r requirements/test.txt, astroid, click-repl, edx-lint, edx-opaque-keys, mock, stevedore
 slumber==0.7.1            # via -r requirements/test.txt
 snowballstemmer==2.0.0    # via pydocstyle
 sqlparse==0.4.1           # via -r requirements/test.txt, django
@@ -67,5 +71,6 @@ super-csv==2.0.0          # via -r requirements/test.txt
 text-unidecode==1.3       # via -r requirements/test.txt, python-slugify
 toml==0.10.2              # via -r requirements/test.txt, pylint, pytest
 urllib3==1.26.2           # via -r requirements/test.txt, requests
-vine==1.3.0               # via -r requirements/test.txt, amqp, celery
+vine==5.0.0               # via -r requirements/test.txt, amqp, celery
+wcwidth==0.2.5            # via -r requirements/test.txt, prompt-toolkit
 wrapt==1.12.1             # via astroid

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -7,7 +7,10 @@
 attrs==20.3.0             # via pytest
 certifi==2020.12.5        # via -r requirements/base.txt, requests
 chardet==4.0.0            # via -r requirements/base.txt, requests
-click==7.1.2              # via code-annotations
+click-didyoumean==0.0.3   # via -r requirements/base.txt, celery
+click-plugins==1.1.1      # via -r requirements/base.txt, celery
+click-repl==0.1.6         # via -r requirements/base.txt, celery
+click==7.1.2              # via -r requirements/base.txt, celery, click-didyoumean, click-plugins, click-repl, code-annotations
 code-annotations==0.10.2  # via -r requirements/test.in
 coverage==5.3.1           # via pytest-cov
 ddt==1.4.1                # via -r requirements/test.in
@@ -29,6 +32,7 @@ newrelic==5.24.0.153      # via -r requirements/base.txt, edx-django-utils
 packaging==20.8           # via pytest
 pbr==5.5.1                # via -r requirements/base.txt, stevedore
 pluggy==0.13.1            # via pytest
+prompt-toolkit==3.0.9     # via -r requirements/base.txt, click-repl
 psutil==5.8.0             # via -r requirements/base.txt, edx-django-utils
 py==1.10.0                # via pytest
 pymongo==3.11.2           # via -r requirements/base.txt, edx-opaque-keys
@@ -37,11 +41,11 @@ pytest-cov==2.10.1        # via -r requirements/test.in
 pytest-django==4.1.0      # via -r requirements/test.in
 pytest==6.2.1             # via pytest-cov, pytest-django
 python-slugify==4.0.1     # via code-annotations
-pytz==2020.4              # via -r requirements/base.txt, celery, django
+pytz==2020.5              # via -r requirements/base.txt, celery, django
 pyyaml==5.3.1             # via code-annotations
 requests==2.25.1          # via -r requirements/base.txt, slumber
 simplejson==3.17.2        # via -r requirements/base.txt, super-csv
-six==1.15.0               # via -r requirements/base.txt, edx-opaque-keys, mock, stevedore
+six==1.15.0               # via -r requirements/base.txt, click-repl, edx-opaque-keys, mock, stevedore
 slumber==0.7.1            # via -r requirements/base.txt
 sqlparse==0.4.1           # via -r requirements/base.txt, django
 stevedore==1.32.0         # via -c requirements/constraints.txt, -r requirements/base.txt, code-annotations, edx-django-utils, edx-opaque-keys
@@ -49,3 +53,4 @@ super-csv==2.0.0          # via -r requirements/base.txt
 text-unidecode==1.3       # via python-slugify
 toml==0.10.2              # via pytest
 urllib3==1.26.2           # via -r requirements/base.txt, requests
+wcwidth==0.2.5            # via -r requirements/base.txt, prompt-toolkit

--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,6 @@ setup(
         'License :: OSI Approved :: GNU Affero General Public License v3 or later (AGPLv3+)',
         'Natural Language :: English',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.8',
     ],
     entry_points={


### PR DESCRIPTION
**Description:**  
- Upgrade celery to 5.0.4
- Bumped Version
- Updated python classifier as python 3.5 is already dropped


**JIRA:** Link to JIRA ticket

**Merge checklist:**
- [x] All reviewers approved
- [x] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [x] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)
