### PR TITLE
EDUCATOR-4698: add assignment grade to bulk grade export

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,7 +13,12 @@ Change Log
 
 Unreleased
 ~~~~~~~~~~
-*
+
+[0.8.6] - 2021-01-22
+~~~~~~~~~~~~~~~~~~~~~
+* Added a management command ``install-local`` that will install your local code into devstack LMS
+* GradeCSVProcessor export now includes an additional column per subsection, ``grade-{subsection_id}``. 
+  This column is equal to the ``original_grade`` column for that subsection if there is no override, or equal to ``previous_override`` if there is an override.
 
 [0.8.5] - 2020-12-24
 ~~~~~~~~~~~~~~~~~~~~~

--- a/Makefile
+++ b/Makefile
@@ -102,3 +102,10 @@ dummy_translations: ## generate dummy translation (.po) files
 build_dummy_translations: extract_translations dummy_translations compile_translations ## generate and compile dummy translation files
 
 validate_translations: build_dummy_translations detect_changed_source_translations ## validate translations
+
+##################
+#Devstack commands
+##################
+
+install-local-bulk-grades: ## installs your local bulk-grades code into the LMS virtualenv
+	docker exec -t edx.devstack.lms bash -c '. /edx/app/edxapp/venvs/edxapp/bin/activate && cd /edx/app/edxapp/edx-platform && pip uninstall -y edx-bulk-grades && pip install -e /edx/src/edx-bulk-grades && pip freeze | grep edx-bulk-grades'

--- a/Makefile
+++ b/Makefile
@@ -107,5 +107,5 @@ validate_translations: build_dummy_translations detect_changed_source_translatio
 #Devstack commands
 ##################
 
-install-local-bulk-grades: ## installs your local bulk-grades code into the LMS virtualenv
+install-local: ## installs your local bulk-grades code into the LMS virtualenv
 	docker exec -t edx.devstack.lms bash -c '. /edx/app/edxapp/venvs/edxapp/bin/activate && cd /edx/app/edxapp/edx-platform && pip uninstall -y edx-bulk-grades && pip install -e /edx/src/edx-bulk-grades && pip freeze | grep edx-bulk-grades'

--- a/README.rst
+++ b/README.rst
@@ -29,6 +29,10 @@ and are on a command prompt inside the LMS container.
 
     pip uninstall edx-bulk-grades -y; pip install -e /edx/src/edx-bulk-grades
 
+   Or, you can run the following make command::
+
+    make install-local
+
 3. Now, get your bulk-grades development environment set up::
 
     cd /edx/src/edx-bulk-grades

--- a/bulk_grades/__init__.py
+++ b/bulk_grades/__init__.py
@@ -2,6 +2,6 @@
 Support for bulk scoring and grading.
 """
 
-__version__ = '0.8.5'
+__version__ = '0.8.6'
 
 default_app_config = 'bulk_grades.apps.BulkGradesConfig'  # pylint: disable=invalid-name

--- a/bulk_grades/api.py
+++ b/bulk_grades/api.py
@@ -265,7 +265,7 @@ class GradeCSVProcessor(DeferrableMixin, GradedSubsectionMixin, CSVProcessor):
     """
 
     required_columns = ['user_id', 'course_id']
-    subsection_prefixes = ('name', 'original_grade', 'previous_override', 'new_override',)
+    subsection_prefixes = ('name', 'grade', 'original_grade', 'previous_override', 'new_override',)
 
     def __init__(self, **kwargs):
         """
@@ -427,11 +427,14 @@ class GradeCSVProcessor(DeferrableMixin, GradedSubsectionMixin, CSVProcessor):
                 row[f'name-{block_id}'] = display_name
                 grade = grades.get(subsection.location, None)
                 if grade:
+                    effective_grade = grade.earned_graded
                     row[f'original_grade-{block_id}'] = grade.earned_graded
                     try:
+                        effective_grade = grade.override.earned_graded_override
                         row[f'previous_override-{block_id}'] = grade.override.earned_graded_override
                     except AttributeError:
                         row[f'previous_override-{block_id}'] = None
+                    row[f'grade-{block_id}'] = effective_grade
             yield row
 
 


### PR DESCRIPTION
added for easier integrations with some masters partners. if there is no override for a subsection, `grade-{subsection_id}` is the original grade. otherwise, it's the override grade.

I also added a install-local-bulk-grades make command to do the same thing as install-local-ora

**JIRA:** [EDUCATOR-4698](https://openedx.atlassian.net/browse/EDUCATOR-4698)

**Testing Instructions**:
 - install-local-bulk-grades from bulk-grades dir
 - make restart-lms from devstack dir
 - go to a course and make some grades, go to localhost:1994/<course_id> (gradebook) and make some overrides
 - navigate to localhost:18000/api/bulk_grades/course/<course_id> and your csv will download
 - MAKE SURE PersistantCourseGradesFlag is enabled!!! http://localhost:18000/admin/grades/persistentgradesenabledflag/

**Merge checklist:**
- [ ] All reviewers approved
- [x] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)
