### PR TITLE
Fix: pre-filtered columns breaking history report

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,22 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[0.8.11] - 2021-07-09
+~~~~~~~~~~~~~~~~~~~~~
+* Fixed a bug causing bulk management import history to break when import had pre-filtered columns
+
+[0.8.10] - 2021-05-14
+~~~~~~~~~~~~~~~~~~~~~
+* Updated dependencies
+
+[0.8.9] - 2021-04-09
+~~~~~~~~~~~~~~~~~~~~~
+* Updated dependencies
+
+[0.8.8] - 2021-04-08
+~~~~~~~~~~~~~~~~~~~~~
+* Added excludedCourseRoles to grade export endpoint
+
 [0.8.7] - 2021-03-15
 ~~~~~~~~~~~~~~~~~~~~~
 * Upgrade super-csv to 2.0.1

--- a/bulk_grades/__init__.py
+++ b/bulk_grades/__init__.py
@@ -2,6 +2,6 @@
 Support for bulk scoring and grading.
 """
 
-__version__ = '0.8.10'
+__version__ = '0.8.11'
 
 default_app_config = 'bulk_grades.apps.BulkGradesConfig'  # pylint: disable=invalid-name

--- a/bulk_grades/api.py
+++ b/bulk_grades/api.py
@@ -473,7 +473,8 @@ class GradeCSVProcessor(DeferrableMixin, GradedSubsectionMixin, CSVProcessor):
 
             # Get changes this row introduced for an as-yet-unmodified subsection
             for subsection in unmodified_subsections:
-                if row[f'new_override-{subsection}'].strip() != '':
+                override_column = f'new_override-{subsection}'
+                if override_column in row and row[override_column].strip() != '':
                     subsections_modified_by_row.add(subsection)
 
             # Remove modified subsections from the unmodified list

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -366,7 +366,16 @@ class TestGradeProcessor(BaseTests):
         assert processor_1.columns == processor_2.columns
         expected_columns = [
             *self.default_headers,
-            *self._headers_for_subsections(['homework', 'lab_ques']),
+            'name-homework',
+            'grade-homework',
+            'original_grade-homework',
+            'previous_override-homework',
+            'new_override-homework',
+            'name-lab_ques',
+            'grade-lab_ques',
+            'original_grade-lab_ques',
+            'previous_override-lab_ques',
+            'new_override-lab_ques',
         ]
         assert expected_columns == processor_1.columns
 
@@ -569,7 +578,11 @@ class TestGradeProcessor(BaseTests):
         headers = rows[0].strip().split(',')
         expected_headers = [
             *self.default_headers,
-            *self._headers_for_subsections(['homework']),
+            'name-homework',
+            'grade-homework',
+            'original_grade-homework',
+            'previous_override-homework',
+            'new_override-homework',
             'status',
             'error']
 
@@ -601,7 +614,11 @@ class TestGradeProcessor(BaseTests):
         headers = rows[0].strip().split(',')
         expected_headers = [
             *self.default_headers,
-            *self._headers_for_subsections(['lab_ques']),
+            'name-lab_ques',
+            'grade-lab_ques',
+            'original_grade-lab_ques',
+            'previous_override-lab_ques',
+            'new_override-lab_ques',
             'status',
             'error'
         ]


### PR DESCRIPTION
**Description:** Column filtering for bulk grade import history worked off the assumption that all subsections were present in the initial grade import. This assumption fails if subsections change or if an instructor trimmed down the original import and made it impossible to view historical reports. This adds a missing null check to handle these cases.

Also makes tests a bit DRYer.

**JIRA:** https://openedx.atlassian.net/browse/AU-5

**Merge checklist:**
- [ ] All reviewers approved
- [x] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)
