### PR TITLE
fix: Gradebook Bulk Management not working with multiple per-user overrides

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,9 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[0.8.12] - 2012-06-21
+* Fixed import csv to not working with multiple sections per-user override
+
 [0.8.11] - 2021-07-09
 ~~~~~~~~~~~~~~~~~~~~~
 * Fixed a bug causing bulk management import history to break when import had pre-filtered columns

--- a/bulk_grades/__init__.py
+++ b/bulk_grades/__init__.py
@@ -2,6 +2,6 @@
 Support for bulk scoring and grading.
 """
 
-__version__ = '0.8.11'
+__version__ = '0.8.12'
 
 default_app_config = 'bulk_grades.apps.BulkGradesConfig'  # pylint: disable=invalid-name


### PR DESCRIPTION
It doesn't seem like original code intended for multiple grade override. With minimal change and minor refactor, it is able to do multiple update. It might be possible to wrap multiple override in a single update request. As for right now, it is sending request to `edx-platform/lms/djangoapps/grades/api.py::override_subsection_grade` for every subsection.

**Description:** 

**JIRA:**[AU-13](https://openedx.atlassian.net/browse/AU-13)

**Reproduce**: You can do this on stage/prod
- Have course that has more than 1 subsection
- Use `bulk management` to export the grades
- Modify grade on `new-override_{subsection-id}`
- Import grade using bulk management
- **You should see only one of the subsection's grade get override**

**Change**
- Follow the reproduce instruction
- **You should see all of the subsection's grade get override**

**Merge checklist:**
- [x] All reviewers approved
- [x] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)
