### PR TITLE
fix: csv import should throw error on repeat user

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,8 +13,10 @@ Change Log
 
 Unreleased
 ~~~~~~~~~~
+[0.8.13] - 2021-07-12
+* Fix bug where we ignore repeat user in the csv import
 
-[0.8.12] - 2012-06-21
+[0.8.12] - 2021-06-21
 * Fixed import csv to not working with multiple sections per-user override
 
 [0.8.11] - 2021-07-09

--- a/bulk_grades/__init__.py
+++ b/bulk_grades/__init__.py
@@ -2,6 +2,6 @@
 Support for bulk scoring and grading.
 """
 
-__version__ = '0.8.12'
+__version__ = '0.8.13'
 
 default_app_config = 'bulk_grades.apps.BulkGradesConfig'  # pylint: disable=invalid-name

--- a/bulk_grades/api.py
+++ b/bulk_grades/api.py
@@ -357,12 +357,13 @@ class GradeCSVProcessor(DeferrableMixin, GradedSubsectionMixin, CSVProcessor):
         Preprocess the CSV row.
         """
         operation = {}
-        if row['user_id'] in self._users_seen:
-            return operation
+        user_id = row['user_id']
+        if user_id in self._users_seen:
+            raise ValidationError(_('Repeated user_id: ') + str(user_id))
 
         operation['new_override_grades'] = []
         operation['course_id'] = self.course_id
-        operation['user_id'] = row['user_id']
+        operation['user_id'] = user_id
 
         for key in row:
             if key.startswith('new_override-'):
@@ -380,7 +381,7 @@ class GradeCSVProcessor(DeferrableMixin, GradedSubsectionMixin, CSVProcessor):
                             raise ValidationError(_('Grade must not be negative'))
                         operation['new_override_grades'].append((block_id, new_grade))
 
-        self._users_seen.add(row['user_id'])
+        self._users_seen.add(user_id)
         return operation
 
     def process_row(self, row):

--- a/bulk_grades/views.py
+++ b/bulk_grades/views.py
@@ -91,6 +91,11 @@ class GradeImportExport(GradeOnlyExport):
             the_file = request.FILES['csv']
             self.processor.process_file(the_file, autocommit=True)
             data = self.processor.status()
+            data['error_messages'] = []
+            for error_message in self.processor.error_messages:
+                line_numbers = ', #'.join(str(line_number+1) for line_number in self.processor.error_messages[error_message])
+                data['error_messages'].append(f'{error_message} on lines (#{line_numbers})')
+
             log.info('Processed file %s for %s -> %s saved, %s processed, %s error. (async=%s)',
                      the_file.name,
                      course_id,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -475,10 +475,12 @@ class TestGradeProcessor(BaseTests):
 
     def test_repeat_user(self):
         processor = api.GradeCSVProcessor(course_id=self.course_id)
+        username = 'ditto'
         row = {
             'block_id': self.usage_key,
             'new_override-85bb02db': '1',
             'user_id': self.learner.id,
+            'username': username,
             'Previous Points': '',
         }
         operation = processor.preprocess_row(row)
@@ -488,12 +490,13 @@ class TestGradeProcessor(BaseTests):
             'block_id': self.usage_key,
             'new_override-123402db': '2',
             'user_id': self.learner.id,
+            'username': username,
             'Previous Points': ''
         }
 
-        # different row with the same user id should not get processed
-        operation = processor.preprocess_row(row2)
-        assert not operation
+        # different row with the same user id throw error
+        with self.assertRaisesMessage(ValidationError, 'Repeated user'):
+            processor.preprocess_row(row2)
 
     def test_empty_grade(self):
         processor = api.GradeCSVProcessor(course_id=self.course_id)


### PR DESCRIPTION
**Description:**
Fix bug where we ignore repeat user in the `csv import`. 

**Change**
- If the user show up more than once in the csv, the import will fail and send back the error message
- All of the error message now will show line number

**JIRA:** [AU-20](https://openedx.atlassian.net/browse/AU-20)

**Merge checklist:**
- [x] All reviewers approved
- [x] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are squashed

**Before**
<img width="2555" alt="Screen Shot 2021-06-24 at 3 36 32 PM" src="https://user-images.githubusercontent.com/83240113/123322279-1aba4d00-d502-11eb-825b-8154a1ce1ac0.png">
**After**
<img width="1503" alt="Screen Shot 2021-07-08 at 1 26 11 PM" src="https://user-images.githubusercontent.com/83240113/124965417-1a38b080-dff0-11eb-9808-efaa3972c9ef.png">

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)
