### PR TITLE
fix: update csv import error messages

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,8 @@ Change Log
 .. There should always be an "Unreleased" section for changes pending release.
 
 Unreleased
+[0.8.14] - 2021-07-12
+* Update csv import error message
 ~~~~~~~~~~
 [0.8.13] - 2021-07-12
 * Fix bug where we ignore repeat user in the csv import

--- a/bulk_grades/__init__.py
+++ b/bulk_grades/__init__.py
@@ -2,6 +2,6 @@
 Support for bulk scoring and grading.
 """
 
-__version__ = '0.8.13'
+__version__ = '0.8.14'
 
 default_app_config = 'bulk_grades.apps.BulkGradesConfig'  # pylint: disable=invalid-name

--- a/bulk_grades/views.py
+++ b/bulk_grades/views.py
@@ -91,8 +91,13 @@ class GradeImportExport(GradeOnlyExport):
             data = self.processor.status()
             data['error_messages'] = []
             for error_message in self.processor.error_messages:
-                line_numbers = ', #'.join(str(line_number+1) for line_number in self.processor.error_messages[error_message])
-                data['error_messages'].append(f'{error_message} on lines (#{line_numbers})')
+                line_numbers = ', '.join(str(line_number+1) for line_number in self.processor.error_messages[error_message])
+                new_message = '{error_message} on line{is_plural} {line_numbers}'.format(
+                                    error_message=error_message,
+                                    is_plural='s' if len(line_numbers) > 1 else '',
+                                    line_numbers=line_numbers
+                                )
+                data['error_messages'].append(new_message)
 
             log.info('Processed file %s for %s -> %s saved, %s processed, %s error. (async=%s)',
                      the_file.name,


### PR DESCRIPTION
**Description:** update csv error according discussed.

**JIRA:** [AU-66](https://openedx.atlassian.net/browse/AU-66)
Linked [PR](https://github.com/edx/frontend-app-gradebook/pull/205)

<img width="1416" alt="Screen Shot 2021-07-22 at 1 23 51 PM" src="https://user-images.githubusercontent.com/83240113/126682153-e751138f-ad75-4b3b-9499-e8f903ac3cb1.png">


**Merge checklist:**
- [x] All reviewers approved
- [x] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are squashed
- [x] Approve and ready to merge on this [pr](https://github.com/edx/frontend-app-gradebook/pull/205)

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)
