### PR TITLE
feat: row first row of error on duplicate user import

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,13 +12,17 @@ Change Log
 .. There should always be an "Unreleased" section for changes pending release.
 
 Unreleased
-[0.8.14] - 2021-07-12
-* Update csv import error message
+[0.9.1] - 2021-08-02
+* Feat repeat user error should also show the first occurence
 ~~~~~~~~~~
 
 [0.9.0] - 2021-07-20
 ~~~~~~~~~~~~~~~~~~~~
 * Added support for django 3.2
+
+[0.8.14] - 2021-07-12
+* Update csv import error message
+=======
 
 [0.8.13] - 2021-07-12
 ~~~~~~~~~~~~~~~~~~~~~

--- a/bulk_grades/__init__.py
+++ b/bulk_grades/__init__.py
@@ -2,6 +2,6 @@
 Support for bulk scoring and grading.
 """
 
-__version__ = '0.9.0'
+__version__ = '0.9.1'
 
 default_app_config = 'bulk_grades.apps.BulkGradesConfig'  # pylint: disable=invalid-name


### PR DESCRIPTION
**Description:** Detect duplicate user_id on the first occurence.

**JIRA:** [AU-44](https://openedx.atlassian.net/browse/AU-44)

**Merge checklist:**
- [x] All reviewers approved
- [x] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Test instruction**
- [ ] import csv into the course with duplicate `user_id`
- [ ] The first occurrent that the user appear should also be included.
![Screen Shot 2021-08-02 at 2 45 32 PM](https://user-images.githubusercontent.com/83240113/127909038-d853c812-e0c3-4717-8a2e-9b932b1aafe9.png)
**Note**: duplicate error and other error are not mutually inclusive. As picture shown, line #2 appear to have different errors.

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)
