### PR TITLE
version bump for super csv to fix history not rendering

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,11 @@ Change Log
 .. There should always be an "Unreleased" section for changes pending release.
 
 Unreleased
+
+[0.9.12 - 2021-09-02
+* Fix grade history not rendering on error
+~~~~~~~~~~
+
 [0.9.1] - 2021-08-02
 * Feat repeat user error should also show the first occurence
 ~~~~~~~~~~

--- a/bulk_grades/__init__.py
+++ b/bulk_grades/__init__.py
@@ -2,6 +2,6 @@
 Support for bulk scoring and grading.
 """
 
-__version__ = '0.9.1'
+__version__ = '0.9.2'
 
 default_app_config = 'bulk_grades.apps.BulkGradesConfig'  # pylint: disable=invalid-name

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -100,7 +100,7 @@ stevedore==3.3.0
     # via
     #   edx-django-utils
     #   edx-opaque-keys
-super-csv==2.1.0
+super-csv==2.1.1
     # via -r requirements/base.in
 urllib3==1.26.6
     # via requests

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -335,7 +335,7 @@ stevedore==3.3.0
     #   code-annotations
     #   edx-django-utils
     #   edx-opaque-keys
-super-csv==2.1.0
+super-csv==2.1.1
     # via -r requirements/quality.txt
 text-unidecode==1.3
     # via

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -284,7 +284,7 @@ stevedore==3.3.0
     #   doc8
     #   edx-django-utils
     #   edx-opaque-keys
-super-csv==2.1.0
+super-csv==2.1.1
     # via -r requirements/test.txt
 text-unidecode==1.3
     # via

--- a/requirements/pii_check.txt
+++ b/requirements/pii_check.txt
@@ -165,7 +165,7 @@ stevedore==3.3.0
     #   code-annotations
     #   edx-django-utils
     #   edx-opaque-keys
-super-csv==2.1.0
+super-csv==2.1.1
     # via -r requirements/base.txt
 text-unidecode==1.3
     # via python-slugify

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -254,7 +254,7 @@ stevedore==3.3.0
     #   code-annotations
     #   edx-django-utils
     #   edx-opaque-keys
-super-csv==2.1.0
+super-csv==2.1.1
     # via -r requirements/test.txt
 text-unidecode==1.3
     # via

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -186,7 +186,7 @@ stevedore==3.3.0
     #   code-annotations
     #   edx-django-utils
     #   edx-opaque-keys
-super-csv==2.1.0
+super-csv==2.1.1
     # via -r requirements/base.txt
 text-unidecode==1.3
     # via python-slugify


### PR DESCRIPTION
**Description:** 
Version bump to fix the history not rendering.

**JIRA:** [AU-115](https://openedx.atlassian.net/browse/AU-115)
**GitHub** [super-csv pr](https://github.com/edx/super-csv/pull/68)

**Merge checklist:**
- [x] All reviewers approved
- [x] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)
