### PR TITLE
build: fix schedule for python req. hygiene github action

### DIFF
--- a/.github/workflows/upgrade-python-requirements.yml
+++ b/.github/workflows/upgrade-python-requirements.yml
@@ -2,8 +2,8 @@ name: Upgrade Requirements
 
 on:
   schedule:
-    # will start the job at 16:15 UTC (roughly) every other Tuesday
-    - cron: "15 16 8-14,22-28 * 2"
+    # will start the job at 16:15 UTC every other week starting on the 9th of the month
+    - cron: "15 16 9/14 * *"
   workflow_dispatch:
     inputs:
       branch:
@@ -65,7 +65,7 @@ jobs:
           subject: Upgrade python requirements workflow failed in ${{github.repository}}
           to: masters-requirements-update@edx.opsgenie.net
           from: github-actions <github-actions@edx.org>
-          body: Upgrade python requirements workflow in ${{github.repository}} failed! For details see "github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          body: Upgrade python requirements workflow executed in ${{github.repository}}. For details see "github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}". Run failed.
 
       - name: Send success notification
         if: ${{ success() }}
@@ -78,4 +78,4 @@ jobs:
           subject: Upgrade python requirements workflow executed successfully in ${{github.repository}}
           to: masters-requirements-update@edx.opsgenie.net
           from: github-actions <github-actions@edx.org>
-          body: Upgrade python requirements workflow in ${{github.repository}} successfully created 'Python Requirements Update' PR. Please review it "github.com/${{ github.repository }}/pulls"
+          body: Upgrade python requirements workflow executed in {{github.repository}}. For details see "github.com/${{ github.repository }}/pulls"


### PR DESCRIPTION
**Description:** makes the python requirements upgrade github action not run every day for a week at a time

**JIRA:** Link to JIRA ticket

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)
