### PR TITLE
chore: remove pins which no longer cause version conflicts

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -17,7 +17,3 @@ django<2.3
 # pinning celery to latest release
 celery<6.0
 
-# Pinning jinja2
-jinja2<3.0
-MarkupSafe<2.0
-click<8.0


### PR DESCRIPTION
these pins were added in
https://github.com/edx/edx-bulk-grades/pull/75 to avoid conflicts
which no longer occur

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)
